### PR TITLE
Nested child views are not rendered

### DIFF
--- a/test/templates/blocks-nested.twig
+++ b/test/templates/blocks-nested.twig
@@ -1,0 +1,1 @@
+{% block body %}parent{% block child %}:child{% endblock %}{% endblock %}

--- a/test/templates/child-blocks-nested.twig
+++ b/test/templates/child-blocks-nested.twig
@@ -1,0 +1,3 @@
+{% extends base %}
+
+{% block body %}parent{% block child %}:child{% endblock %}{% endblock %}

--- a/test/test.fs.js
+++ b/test/test.fs.js
@@ -102,6 +102,32 @@ describe("Twig.js Blocks ->", function() {
             }
         });
     });
+
+    it("should render nested blocks", function(done) {
+        // Test rendering of blocks within blocks
+        twig({
+            id:     'blocks-nested',
+            path:   'test/templates/blocks-nested.twig',
+
+            load: function(template) {
+                template.render({ }).should.equal( "parent:child" )
+                done();
+            }
+        })
+    });
+
+    it("should render extended nested blocks", function(done) {
+        // Test rendering of blocks within blocks
+        twig({
+            id:     'child-blocks-nested',
+            path:   'test/templates/child-blocks-nested.twig',
+
+            load: function(template) {
+                template.render({ base: "template.twig" }).should.equal( "Default Title - parent:child" )
+                done();
+            }
+        })
+    });
 });
 
 


### PR DESCRIPTION
Refs #51
- [x] Create tests showing the issue
- [x] Identify solution
- [x] Commit patch

You can see how nested blocks render correctly by themselves, but the child blocks are not rendered when the template `extends` another:

`$ ./node_modules/.bin/mocha test/test.fs.js --require should --grep "nested"`

This code base is...complicated, so any help with _where_ this logic may be going wrong would really help, @justjohn :)

If you replace [twig.js#L307](https://github.com/justjohn/twig.js/blob/master/twig.js#L307) with the following, this _one test passes_, but severely breaks all others.  A clue, perhaps?

``` js
intermediate_output = [];
```

becomes:

``` js
if (prev_token.type !== Twig.logic.type.block) {
    intermediate_output = [];
}
```
