### PR TITLE
List unsupported tests in testphp

### DIFF
--- a/test-ext/test.original.js
+++ b/test-ext/test.original.js
@@ -58,7 +58,7 @@
 					return res;
 				};
 
-			walk( twigPhpDir + "/test/", function( err, files ) {
+			walk( twigPhpDir + "/test", function( err, files ) {
 				var testFiles = [];
 
 				files.forEach( function( filepath ) {
@@ -76,6 +76,25 @@
 					;
 
 					if ( !data.DATA || data.DATA.match( /^class|\$|^date_default_timezone_set|new Twig|new SimpleXMLElement|new ArrayObject|new ArrayIterator/ ) ) {
+						if ( data.EXCEPTION ) {
+							it( data.filepath + " -> " + data.TEST.trim( ), function( ) {
+								try {
+									twig( {
+										"data" : data.TEMPLATE.trim( )
+									} )
+									.render( res )
+									.trim( );
+								} catch( exp ) {
+									return;
+								}
+
+								throw "Should have thrown an exception: " + data.EXCEPTION;
+							} );
+						} else {
+							it( data.filepath + " -> " + data.TEST.trim( ), function( ) {
+								throw "Unsupported";
+							} );
+						}
 						delete testFiles[ idx ];
 						return;
 					}


### PR DESCRIPTION
I deliberately ignored tests without test data and with invalid test data (PHP Classes and so on).

This meant that the failed test count was lower than it actually was and that tests that are suppose to throw an exception were also ignored.

This marked the unsupported tests as failed and tests that the tests that are suppose to throw exception do that.
The idea here is that all the tests with the invalid test data, should've a test-by-test manually implemented JS-data-set.

Sorry, but this pull request increases the failed test count to 154 :-1: 
