### PR TITLE
Support endblock extended syntax

### DIFF
--- a/twig.js
+++ b/twig.js
@@ -2021,7 +2021,7 @@ var Twig = (function (Twig) {
              *  Format: {% endfilter %}
              */
             type: Twig.logic.type.endblock,
-            regex: /^endblock$/,
+            regex: /^endblock(\s+([a-zA-Z0-9_]+))?$/,
             next: [ ],
             open: false
         },


### PR DESCRIPTION
Why do not support closing block with name ?
{% block body %}
{% endblock body %}

Is that commit break something else ?
