### PR TITLE
Set the proper console context when calling Twig.log.error

### DIFF
--- a/src/twig.core.js
+++ b/src/twig.core.js
@@ -146,7 +146,9 @@ var Twig = (function (Twig) {
 
     if (typeof console !== "undefined" && 
         typeof console.log !== "undefined") {
-        Twig.log.error = console.log;
+        Twig.log.error = function() {
+            console.log.apply(console, arguments);
+        }
     } else {
         Twig.log.error = function(){};
     }


### PR DESCRIPTION
In Google Chrome, the console methods throw an "Illegal invocation" error if called with a context other then console:

```
var myFunc = console.log;
myFunc("foo"); 
```

The log wrapper in Twig.js makes the same mistake:

```
Twig.log.error = console.log
```

I solved this problem by applying the proper context.
