### PR TITLE
Implemented tests of array casting

### DIFF
--- a/test/test.expressions.js
+++ b/test/test.expressions.js
@@ -221,9 +221,8 @@ describe("Twig.js Expressions ->", function() {
             test_template.render({a:['value']}).should.equal('true');
             test_template.render({a:[]}).should.equal('false');
         });
-        it("should correctly cast arrays", function () {
-            var test_template = twig({data: '{{ (a and a) }}'});
-            test_template.render({a:[]}).should.equal('false');
+        it("should correctly cast arrays in control structures", function () {
+            var test_template = twig({data: '{% if false %}{% elseif a is defined and a %}true{% else %}false{% endif %}'});
             test_template.render({a:['value']}).should.equal('true');
         });
     });

--- a/test/test.expressions.js
+++ b/test/test.expressions.js
@@ -216,6 +216,16 @@ describe("Twig.js Expressions ->", function() {
             test_template.render({a:false}).should.equal(true.toString());
             test_template.render({a:true}).should.equal(false.toString());
         });
+        it("should correctly cast arrays", function () {
+            var test_template = twig({data: '{{ a == true }}'});
+            test_template.render({a:['value']}).should.equal('true');
+            test_template.render({a:[]}).should.equal('false');
+        });
+        it("should correctly cast arrays", function () {
+            var test_template = twig({data: '{{ (a and a) }}'});
+            test_template.render({a:[]}).should.equal('false');
+            test_template.render({a:['value']}).should.equal('true');
+        });
     });
 
     describe("Other Operators ->", function() {


### PR DESCRIPTION
Incorrect typecasting empty array to boolean. There are two cases:
1. Empty array not casted to `false`;
2. For some reason not empty array in `elseif` block cast to `false`;