### PR TITLE
Replace Twig.exports.cache by setCache

### DIFF
--- a/twig.js
+++ b/twig.js
@@ -6514,7 +6514,7 @@ var Twig = (function (Twig) {
      *
      * @param {boolean} cache
      */
-    Twig.exports.cache = function(cache) {
+    Twig.exports.setCache = function(cache) {
         Twig.cache = cache;
     };
 


### PR DESCRIPTION
As Twig.exports.cache is a function, this naming might be confusing for the user. setCache fits better.
