### PR TITLE
Adjust in/not in operator precedence

### DIFF
--- a/src/twig.expression.operator.js
+++ b/src/twig.expression.operator.js
@@ -36,8 +36,6 @@ module.exports = function (Twig) {
     Twig.expression.operator.lookup = function (operator, token) {
         switch (operator) {
             case "..":
-            case 'not in':
-            case 'in':
                 token.precidence = 20;
                 token.associativity = Twig.expression.operator.leftToRight;
                 break;
@@ -74,10 +72,11 @@ module.exports = function (Twig) {
             case '<=':
             case '>':
             case '>=':
+            case 'not in':
+            case 'in':
                 token.precidence = 8;
                 token.associativity = Twig.expression.operator.leftToRight;
                 break;
-
 
             case '~': // String concatination
             case '+':

--- a/test/test.expressions.operators.js
+++ b/test/test.expressions.operators.js
@@ -1,0 +1,13 @@
+var Twig = Twig || require("../twig"),
+    twig = twig || Twig.twig;
+
+describe("Twig.js Expression Operators ->", function() {
+    describe("Precedence ->", function() {
+        it("should correctly order 'in'", function() {
+            var test_template = twig({data: '{% if true or "anything" in ["a","b","c"] %}OK!{% endif %}'}),
+                output = test_template.render({});
+
+            output.should.equal("OK!");
+        });
+    });
+});


### PR DESCRIPTION
I'd like some comments on this one before it gets merged from @plepe or @justjohn or @evgenius.

Our source states that we follow C operator precedence (https://en.wikipedia.org/wiki/Operators_in_C_and_C%2B%2B#Operator_precedence), but obviously there is no `in` statement in C.

The closest language I could find was JavaScript ;) https://developer.mozilla.org/en/docs/Web/JavaScript/Reference/Operators/Operator_Precedence and this puts `in` precedence at the same level as <,<=,>,>= so that is what I've done here.

All existing tests pass, my new test passes, but I've got a feeling this could really do with a larger suite considering the magnitude of the change.

Any thoughts appreciated!