### PR TITLE
Return rendered template as a string (for express)

### DIFF
--- a/src/twig.exports.js
+++ b/src/twig.exports.js
@@ -174,8 +174,8 @@ module.exports = function (Twig) {
             path: path,
             base: settings.views,
             load: function(template) {
-                // render and return template
-                fn(null, template.render(options));
+                // render and return template as a simple string, see https://github.com/twigjs/twig.js/pull/348 for more information
+                fn(null, '' + template.render(options));
             }
         };
 

--- a/test/test.exports.js
+++ b/test/test.exports.js
@@ -1,0 +1,21 @@
+var Twig = Twig || require("../twig"),
+    twig = twig || Twig.twig;
+
+describe("Twig.js Exports __express ->", function() {
+    /* otherwise express will return it as JSON, see: https://github.com/twigjs/twig.js/pull/348 for more information */
+    it("should return a string (and not a String)", function(done) {
+    	var flags = {};
+
+    	Twig.__express('test/templates/test.twig', {
+          "settings": {
+            "twig options": {
+              "autoescape": "html"
+            }
+          }
+    	}, function(err, response) {
+            var responseType = (typeof response);
+            responseType.should.equal('string');
+            done();
+        });
+    });
+});


### PR DESCRIPTION
Because https://github.com/expressjs/express/blob/b5a2801/lib/response.js#L136 does not work with `String`, which is created at https://github.com/twigjs/twig.js/blob/274a3ce830be07f10a9d1c09d7a2f671adceb649/src/twig.core.js#L1319

If this patch is not applied and you use twig.js with express like this:

``` js
app.set('twig options', {
  autoescape: 'html'
});
```

then the returned value would be a "String" and not a "string". So express handles this by returning the value as `res.json()` :(.

So the html page looks like this:

``` json
"\n<!DOCTYPE HTML>\n<html la.."
``` 

Of course the HTML should not be delivered as JSON if the user wants the contents to be escaped ;).


PS: Workaround for others with the same issue:

``` js
app.engine('twig', function(path, options, fn) {
  Twig.__express(path, options, function(err, response) {
    fn(err, "" + response);
  });
});
```