### PR TITLE
Allow keys as expressions

### DIFF
--- a/test/test.expressions.js
+++ b/test/test.expressions.js
@@ -319,5 +319,11 @@ describe("Twig.js Expressions ->", function() {
             var output = test_template.render({});
             output.should.equal('ok');
         });
+
+        it('should support keys as expressions', function() {
+            var test_template = twig({data: '{% for val in arr %}{{{(val.value):null}|json_encode}}{% endfor %}'});
+            var output = test_template.render({'arr': [{'value': 'one'}, {'value': 'two'}]});
+            output.should.equal('{"one":null}{"two":null}');
+        });
     });
 });


### PR DESCRIPTION
I think this went in as part of Twig 1.5

```
{# keys as expressions (the expression must be enclosed into parentheses) -- as of Twig 1.5 #}
> { (1 + 1): 'foo', (a ~ 'b'): 'bar' }
```