### PR TITLE
Update parent context when extending a template

### DIFF
--- a/src/twig.lib.js
+++ b/src/twig.lib.js
@@ -35,6 +35,19 @@ module.exports = function(Twig) {
         return target;
     };
 
+    Twig.lib.extend = function (src, add) {
+        var keys = Object.keys(add),
+            i;
+
+        i = keys.length;
+
+        while (i--) {
+            src[keys[i]] = add[keys[i]];
+        }
+
+        return src;
+    };
+
     Twig.lib.replaceAll = function(string, search, replace) {
         return string.split(search).join(replace);
     };

--- a/src/twig.logic.js
+++ b/src/twig.logic.js
@@ -599,11 +599,26 @@ module.exports = function (Twig) {
                 return token;
             },
             parse: function (token, context, chain) {
+                var template,
+                    innerContext = Twig.ChildContext(context);
                 // Resolve filename
                 var file = Twig.expression.parse.apply(this, [token.stack, context]);
 
                 // Set parent template
                 this.extend = file;
+
+                if (file instanceof Twig.Template) {
+                    template = file;
+                } else {
+                    // Import file
+                    template = this.importFile(file);
+                }
+
+                // Render the template in case it puts anything in its context
+                template.render(innerContext);
+
+                // Extend the parent context with the extended context
+                Twig.lib.extend(context, innerContext);
 
                 return {
                     chain: chain,

--- a/test/templates/extendee.twig
+++ b/test/templates/extendee.twig
@@ -1,0 +1,6 @@
+{% macro macro() %}ok!{% endmacro %}
+{% import _self as my %}
+
+{% block content %}
+<p>Sub: content</p>
+{% endblock %}

--- a/test/templates/extender.twig
+++ b/test/templates/extender.twig
@@ -1,0 +1,5 @@
+{% extends 'extendee.twig' %}
+
+{% block content %}
+{{ my.macro({}) }}
+{% endblock %}

--- a/test/test.extends.js
+++ b/test/test.extends.js
@@ -142,4 +142,15 @@ describe("Twig.js Extensions ->", function() {
         var result = twig({data:"{% noop %}"}).render();
         result.should.equal("noop2");
     });
+
+	it("should extend the parent context when extending", function() {
+		var template = twig({
+			path: 'test/templates/extender.twig',
+			async: false
+		});
+
+		var output = template.render();
+
+		output.trim().should.equal("ok!");
+	});
 });


### PR DESCRIPTION
Previously, if your parent template `extends` another template, and in that "sub" template you do something with the context, like define a macro, these changes are not available in the parent template.