### PR TITLE
Allow the `elseif` statement to accept truthy values

### DIFF
--- a/src/twig.logic.js
+++ b/src/twig.logic.js
@@ -131,9 +131,10 @@ module.exports = function (Twig) {
                 return token;
             },
             parse: function (token, context, chain) {
-                var output = '';
+                var output = '',
+                    result = Twig.expression.parse.apply(this, [token.stack, context]);
 
-                if (chain && Twig.expression.parse.apply(this, [token.stack, context]) === true) {
+                if (chain && result) {
                     chain = false;
                     // parse if output
                     output = Twig.parse.apply(this, [token.output, context]);

--- a/test/test.controlStructures.js
+++ b/test/test.controlStructures.js
@@ -34,6 +34,12 @@ describe("Twig.js Control Structures ->", function() {
             test_template.render({test: true, other: false}).should.equal("true" );
             test_template.render({test: false, other: false}).should.equal("" );
         });
+        it("should support values which are not booleans", function () {
+            var test_template = twig({data: '{% if test %}test_true{% elseif other %}other_true{% else %}all_false{% endif %}'});
+            test_template.render({test: "true", other: true}).should.equal("test_true");
+            test_template.render({test: false, other: "true"}).should.equal("other_true");
+            test_template.render({test: false, other: false}).should.equal("all_false");
+        });
     });
 
     // {% for ... %}


### PR DESCRIPTION
This allows the `elseif` statement to accept the same values as the `if` statement by using loose comparison. A test is included.