### PR TITLE
Match what PHP considers falsy values

### DIFF
--- a/src/twig.expression.operator.js
+++ b/src/twig.expression.operator.js
@@ -139,7 +139,7 @@ module.exports = function (Twig) {
                 break;
 
             case '?:':
-                if (a) {
+                if (Twig.lib.boolval(a)) {
                     stack.push(a);
                 } else {
                     stack.push(b);
@@ -153,7 +153,7 @@ module.exports = function (Twig) {
                     c = undefined;
                 }
 
-                if (a) {
+                if (Twig.lib.boolval(a)) {
                     stack.push(b);
                 } else {
                     stack.push(c);

--- a/src/twig.lib.js
+++ b/src/twig.lib.js
@@ -19,6 +19,7 @@ module.exports = function(Twig) {
     Twig.lib.strip_tags = require('locutus/php/strings/strip_tags');
     Twig.lib.strtotime = require('locutus/php/datetime/strtotime');
     Twig.lib.date = require('locutus/php/datetime/date');
+    Twig.lib.boolval = require('locutus/php/var/boolval');
 
     Twig.lib.is = function(type, obj) {
         var clas = Object.prototype.toString.call(obj).slice(8, -1);

--- a/src/twig.logic.js
+++ b/src/twig.logic.js
@@ -95,7 +95,7 @@ module.exports = function (Twig) {
                 // Start a new logic chain
                 chain = true;
 
-                if (result) {
+                if (Twig.lib.boolval(result)) {
                     chain = false;
                     // parse if output
                     output = Twig.parse.apply(this, [token.output, context]);
@@ -134,7 +134,7 @@ module.exports = function (Twig) {
                 var output = '',
                     result = Twig.expression.parse.apply(this, [token.stack, context]);
 
-                if (chain && result) {
+                if (chain && Twig.lib.boolval(result)) {
                     chain = false;
                     // parse if output
                     output = Twig.parse.apply(this, [token.output, context]);

--- a/test/test.controlStructures.js
+++ b/test/test.controlStructures.js
@@ -39,6 +39,14 @@ describe("Twig.js Control Structures ->", function() {
             test_template.render({test: "true", other: true}).should.equal("test_true");
             test_template.render({test: false, other: "true"}).should.equal("other_true");
             test_template.render({test: false, other: false}).should.equal("all_false");
+
+            test_template.render({test: 0, other: true}).should.equal("other_true");
+            test_template.render({test: 0.0, other: true}).should.equal("other_true");
+            test_template.render({test: "", other: true}).should.equal("other_true");
+            test_template.render({test: "0", other: true}).should.equal("other_true");
+            test_template.render({test: [], other: true}).should.equal("other_true");
+            test_template.render({test: null, other: true}).should.equal("other_true");
+            test_template.render({test: undefined, other: true}).should.equal("other_true");
         });
     });
 

--- a/test/test.expressions.js
+++ b/test/test.expressions.js
@@ -276,7 +276,19 @@ describe("Twig.js Expressions ->", function() {
 
             output2.should.equal( "1" );
         });
-        
+        it("should support non-boolean values in ternary statement", function() {
+            var test_template = twig({data: '{{ test ? "true" : "false" }}'});
+
+            test_template.render({test: "one"}).should.equal("true");
+            test_template.render({test: 0}).should.equal("false");
+            test_template.render({test: 0.0}).should.equal("false");
+            test_template.render({test: ""}).should.equal("false");
+            test_template.render({test: "0"}).should.equal("false");
+            test_template.render({test: []}).should.equal("false");
+            test_template.render({test: null}).should.equal("false");
+            test_template.render({test: undefined}).should.equal("false");
+        });
+
         it("should support in/containment functionality for arrays", function() {
             var test_template = twig({data: '{{ "a" in ["a", "b", "c"] }}'});
             test_template.render().should.equal(true.toString());


### PR DESCRIPTION
This uses the `boolval` function from `locutus` in `if`, `elseif`, and ternary operations (`?`, `?:`) to determine what passes according to what PHP [considers falsy values](http://us2.php.net/manual/en/language.types.boolean.php#language.types.boolean.casting). Tests included.