### PR TITLE
Fix `not` operation occurring after binary operators

### DIFF
--- a/src/twig.expression.operator.js
+++ b/src/twig.expression.operator.js
@@ -121,7 +121,9 @@ module.exports = function (Twig) {
         }
 
         b = stack.pop();
-        a = stack.pop();
+        if (operator !== 'not') {
+            a = stack.pop();
+        }
 
         if (operator !== 'in' && operator !== 'not in') {
             if (a && Array.isArray(a)) {
@@ -203,7 +205,7 @@ module.exports = function (Twig) {
 
             case 'not':
             case '!':
-                stack.push(!b);
+                stack.push(!Twig.lib.boolval(b));
                 break;
 
             case '<':

--- a/test/test.expressions.js
+++ b/test/test.expressions.js
@@ -239,8 +239,17 @@ describe("Twig.js Expressions ->", function() {
         });
         it("should support boolean not", function() {
             var test_template = twig({data: '{{ not a }}'});
-            test_template.render({a:false}).should.equal(true.toString());
-            test_template.render({a:true}).should.equal(false.toString());
+            test_template.render({a: false}).should.equal('true');
+            test_template.render({a: true}).should.equal('false');
+            test_template.render({a: '0'}).should.equal('true');
+
+            test_template = twig({data: '{{ a and not b }}'});
+            test_template.render({a: true, b: false}).should.equal('true');
+            test_template.render({a: true, b: true}).should.equal('false');
+
+            test_template = twig({data: '{{ a or not b }}'});
+            test_template.render({a: false, b: false}).should.equal('true');
+            test_template.render({a: false, b: true}).should.equal('false');
         });
 
         it("should correctly cast arrays", function () {


### PR DESCRIPTION
Whenever `not` was in the second position of a binary operation like `and` or `or`, the entire operation would evaluate to `false` because the first expression would be popped off the stack even though the `not` operation would only apply to the second expression. When the `not` operation was found in the first position, the applicable expression was the only one in the stack, so popping the stack a second time had no effect and would appear to work correctly.

This PR only pops the stack once to get the applicable expression and then converts it to a boolean. Tests included.