### PR TITLE
Use the current context when parsing include file name

### DIFF
--- a/src/twig.logic.js
+++ b/src/twig.logic.js
@@ -717,7 +717,7 @@ module.exports = function (Twig) {
                     }
                 }
 
-                var file = Twig.expression.parse.apply(this, [token.stack, innerContext]);
+                var file = Twig.expression.parse.apply(this, [token.stack, context]);
 
                 if (file instanceof Twig.Template) {
                     template = file;

--- a/test/test.core.js
+++ b/test/test.core.js
@@ -405,6 +405,20 @@ describe("Twig.js Core ->", function() {
                 data: '{% set value = "test" %}{% for i in [0, 1] %}{% include "included" %}{% endfor %}{{ value }}'
             }).render().should.equal("test\ninc\ntest\ninc\ntest");
         });
+
+        it("should use the correct context for variables in the included template name", function () {
+            twig({
+                id: 'included-template',
+                data: '{{ value }} - {{ prefix }}'
+            });
+            twig({
+                allowInlineIncludes: true,
+                data: '{% include prefix ~ "-template" with {"value": value} only %}'
+            }).render({
+                prefix: "included",
+                value: "test"
+            }).should.equal("test - ");
+        });
     });
 });
 


### PR DESCRIPTION
This fixes #394 and #231.
The context for the included file was being used to resolve the file name. When the `only` keyword was used, variables used in the filename could become undefined if they were not in a `with` statement. This changes it to always use the context of the `include` statement itself and not the included file.
Test included.