### PR TITLE
Adding support of 'same as'

### DIFF
--- a/src/twig.expression.js
+++ b/src/twig.expression.js
@@ -133,7 +133,7 @@ module.exports = function (Twig) {
     Twig.expression.definitions = [
         {
             type: Twig.expression.type.test,
-            regex: /^is\s+(not)?\s*([a-zA-Z_][a-zA-Z0-9_]*)/,
+            regex: /^is\s+(not)?\s*([a-zA-Z_][a-zA-Z0-9_]*(\s?as)?)/,
             next: Twig.expression.set.operations.concat([Twig.expression.type.parameter.start]),
             compile: function(token, stack, output) {
                 token.filter   = token.match[2];

--- a/src/twig.tests.js
+++ b/src/twig.tests.js
@@ -39,7 +39,7 @@ module.exports = function (Twig) {
         },
         sameas: function(value, params) {
             console.warn('`sameas` is deprecated use `same as`');
-            return Twig.test['same as'](value, params);
+            return Twig.tests['same as'](value, params);
         },
         iterable: function(value) {
             return value && (Twig.lib.is("Array", value) || Twig.lib.is("Object", value));

--- a/src/twig.tests.js
+++ b/src/twig.tests.js
@@ -34,8 +34,12 @@ module.exports = function (Twig) {
         'null': function(value) {
             return this.none(value); // Alias of none
         },
-        sameas: function(value, params) {
+        'same as': function(value, params) {
             return value === params[0];
+        },
+        sameas: function(value, params) {
+            console.warn('`sameas` is deprecated use `same as`');
+            return Twig.test['same as'](value, params);
         },
         iterable: function(value) {
             return value && (Twig.lib.is("Array", value) || Twig.lib.is("Object", value));

--- a/test/test.tests.js
+++ b/test/test.tests.js
@@ -79,7 +79,7 @@ describe("Twig.js Tests ->", function() {
         });
     });
 
-    describe("sameas test ->", function() {
+    describe("`sameas` backwards compatibility with `same as`", function () {
         it("should identify the exact same type as true", function() {
             twig({data: '{{ true is sameas(true) }}'}).render().should.equal("true");
             twig({data: '{{ a is sameas(1) }}'}).render({a: 1}).should.equal("true");
@@ -91,6 +91,21 @@ describe("Twig.js Tests ->", function() {
             twig({data: '{{ true is sameas(1) }}'}).render().should.equal("false");
             twig({data: '{{ false is sameas("") }}'}).render().should.equal("false");
             twig({data: '{{ a is sameas(1) }}'}).render({a: "1"}).should.equal("false");
+        });
+    });
+
+    describe("same as test ->", function() {
+        it("should identify the exact same type as true", function() {
+            twig({data: '{{ true is same as(true) }}'}).render().should.equal("true");
+            twig({data: '{{ a is same as(1) }}'}).render({a: 1}).should.equal("true");
+            twig({data: '{{ a is same as("test") }}'}).render({a: "test"}).should.equal("true");
+            twig({data: '{{ a is same as(true) }}'}).render({a: true}).should.equal("true");
+        });
+        it("should identify the different types as false", function() {
+            twig({data: '{{ false is same as(true) }}'}).render().should.equal("false");
+            twig({data: '{{ true is same as(1) }}'}).render().should.equal("false");
+            twig({data: '{{ false is same as("") }}'}).render().should.equal("false");
+            twig({data: '{{ a is same as(1) }}'}).render({a: "1"}).should.equal("false");
         });
     });
 


### PR DESCRIPTION
`sameas` is deprecated
Ref.: https://github.com/twigphp/Twig/blob/1.x/doc/deprecated.rst