### PR TITLE
Ensure an error during async fs loading uses the error callback

### DIFF
--- a/src/twig.loader.fs.js
+++ b/src/twig.loader.fs.js
@@ -49,7 +49,10 @@ module.exports = function(Twig) {
         if (params.async) {
             fs.stat(params.path, function (err, stats) {
                 if (err || !stats.isFile()) {
-                    throw new Twig.Error('Unable to find template file ' + params.path);
+                    if (typeof error_callback === 'function') {
+                        error_callback(new Twig.Error('Unable to find template file ' + params.path));
+                    }
+                    return;
                 }
                 fs.readFile(params.path, 'utf8', loadTemplateFn);
             });

--- a/test/test.fs.js
+++ b/test/test.fs.js
@@ -91,7 +91,7 @@ describe("Twig.js Include ->", function() {
         twig({ref: 'include-only'}).render({test: 'tst'}).should.equal( "template: before,-mid-template: after," );
     });
 
-    it("should skip an non existant included template flagged wth 'ignore missing'", function() {
+    it("should skip a nonexistent included template flagged wth 'ignore missing'", function() {
         twig({
             id:   'include-ignore-missing',
             path: 'test/templates/include-ignore-missing.twig',
@@ -101,7 +101,7 @@ describe("Twig.js Include ->", function() {
         twig({ref: 'include-ignore-missing'}).render().should.equal( "ignore-missing" );
     });
 
-    it("should fail including an non existant included template not flagged wth 'ignore missing'", function() {
+    it("should fail including a nonexistent included template not flagged wth 'ignore missing'", function() {
         try {
             twig({
                 id: 'include-ignore-missing-missing',
@@ -112,6 +112,23 @@ describe("Twig.js Include ->", function() {
         } catch (err) {
             err.type.should.equal('TwigException');
         }
+    });
+
+    it("should fail including a nonexistent included template asynchronously", function(done) {
+        twig({
+            id: 'include-ignore-missing-missing-async',
+            path: 'test/templates/include-ignore-missing-missing-async.twig',
+            async: true,
+            load: function(template) {
+                template.should.not.exist();
+                done();
+            },
+            error: function(err) {
+                err.type.should.equal('TwigException');
+                done();
+            },
+            rethrow: true
+        });
     });
 });
 


### PR DESCRIPTION
When using the fs loader, passing the async flag and an error callback function to `twig()` should ensure that if the loader encounters an error (such as "file not found", etc.) that it uses the given error callback.

Unfortunately, the fs loader currently throws an error and ignores the error callback when the file specified in `path` is not a file or does not exist.

Here's the fix. And I've added a test that fails if the fix is not implemented.