### PR TITLE
Spaceless tag now re-wraps output as Twig.Markup

### DIFF
--- a/src/twig.logic.js
+++ b/src/twig.logic.js
@@ -759,7 +759,8 @@ module.exports = function (Twig) {
                     rBetweenTagSpaces = />\s+</g,
                     // Replace all space between closing and opening html tags
                     output = unfiltered.replace(rBetweenTagSpaces,'><').trim();
-
+                    // Rewrap output as a Twig.Markup
+                    output = Twig.Markup(output);
                 return {
                     chain: chain,
                     output: output

--- a/test/test.tags.js
+++ b/test/test.tags.js
@@ -11,4 +11,13 @@ describe("Twig.js Tags ->", function() {
         );
     });
 
+    it("should not escape static values when using spaceless", function() {
+        twig({
+            autoescape: true,
+            data: "{% spaceless %}<div>{% endspaceless %}"
+        }).render().should.equal(
+            "<div>"
+        );
+    });
+
 });


### PR DESCRIPTION
This fixes #372.

Previously this tag returned a pure string, but this means that when the output is later run through the output function, it will escape the output, which isn't what we want when Spaceless wraps static values.