### PR TITLE
Fix 'from' tag logic and corresponding test

### DIFF
--- a/src/twig.logic.js
+++ b/src/twig.logic.js
@@ -899,14 +899,14 @@ module.exports = function (Twig) {
             open: true,
             compile: function (token) {
                 var expression = token.match[1].trim(),
-                    macroExpressions = token.match[2].trim().split(/[ ,]+/),
+                    macroExpressions = token.match[2].trim().split(/\s*,\s*/),
                     macroNames = {};
 
                 for (var i=0; i<macroExpressions.length; i++) {
                     var res = macroExpressions[i];
 
                     // match function as variable
-                    var macroMatch = res.match(/^([a-zA-Z0-9_]+)\s+(.+)\s+as\s+([a-zA-Z0-9_]+)$/);
+                    var macroMatch = res.match(/^([a-zA-Z0-9_]+)\s+as\s+([a-zA-Z0-9_]+)$/);
                     if (macroMatch) {
                         macroNames[macroMatch[1].trim()] = macroMatch[2].trim();
                     }

--- a/test/templates/from.twig
+++ b/test/templates/from.twig
@@ -1,1 +1,1 @@
-{% from "macro.twig" import echo %}{{ echo("Twig.js") }}{% from "macro-wrapped.twig" import wrapped_input as input, red_input %}{{ wrapped_input('text') }}{{ red_input('password') }}
+{% from "macro.twig" import echo %}{{ echo("Twig.js") }}{% from "macro-wrapped.twig" import wrapped_input as input, red_input %}{{ input('text') }}{{ red_input('password') }}


### PR DESCRIPTION
Aliases in `from` tag are ignored.
Test is passing, because it isn't actually testing for aliases.

This PR fixes:
- regular expressions for parsing aliases in `from` tag
- `from` tag test template to actually test for aliases