### PR TITLE
Replace `ChildContext` with simple object

### DIFF
--- a/src/twig.core.js
+++ b/src/twig.core.js
@@ -167,17 +167,6 @@ module.exports = function (Twig) {
     }
 
     /**
-     * Wrapper for child context objects in Twig.
-     *
-     * @param {Object} context Values to initialize the context with.
-     */
-    Twig.ChildContext = function(context) {
-        var ChildContext = function ChildContext() {};
-        ChildContext.prototype = context;
-        return new ChildContext();
-    };
-
-    /**
      * Container for methods related to handling high level template tokens
      *      (for example: {{ expression }}, {% logic %}, {# comment #}, raw data)
      */

--- a/src/twig.logic.js
+++ b/src/twig.logic.js
@@ -260,7 +260,7 @@ module.exports = function (Twig) {
                     },
                     // run once for each iteration of the loop
                     loop = function(key, value) {
-                        var inner_context = Twig.ChildContext(context);
+                        var inner_context = Twig.lib.copy(context);
 
                         inner_context[token.value_var] = value;
 
@@ -600,8 +600,7 @@ module.exports = function (Twig) {
                 return token;
             },
             parse: function (token, context, chain) {
-                var template,
-                    innerContext = Twig.ChildContext(context);
+                var template;
                 // Resolve filename
                 var file = Twig.expression.parse.apply(this, [token.stack, context]);
 
@@ -616,10 +615,7 @@ module.exports = function (Twig) {
                 }
 
                 // Render the template in case it puts anything in its context
-                template.render(innerContext);
-
-                // Extend the parent context with the extended context
-                Twig.lib.extend(context, innerContext);
+                template.render(context);
 
                 return {
                     chain: chain,
@@ -705,16 +701,11 @@ module.exports = function (Twig) {
                     template;
 
                 if (!token.only) {
-                    innerContext = Twig.ChildContext(context);
+                    innerContext = Twig.lib.copy(context);
                 }
 
                 if (token.withStack !== undefined) {
-                    withContext = Twig.expression.parse.apply(this, [token.withStack, context]);
-
-                    for (i in withContext) {
-                        if (withContext.hasOwnProperty(i))
-                            innerContext[i] = withContext[i];
-                    }
+                    Twig.lib.extend(innerContext, Twig.expression.parse.apply(this, [token.withStack, context]));
                 }
 
                 var file = Twig.expression.parse.apply(this, [token.stack, context]);
@@ -1003,19 +994,11 @@ module.exports = function (Twig) {
                     template;
 
                 if (!token.only) {
-                    for (i in context) {
-                        if (context.hasOwnProperty(i))
-                            innerContext[i] = context[i];
-                    }
+                    innerContext = Twig.lib.copy(context);
                 }
 
                 if (token.withStack !== undefined) {
-                    withContext = Twig.expression.parse.apply(this, [token.withStack, context]);
-
-                    for (i in withContext) {
-                        if (withContext.hasOwnProperty(i))
-                            innerContext[i] = withContext[i];
-                    }
+                    Twig.lib.extend(innerContext, Twig.expression.parse.apply(this, [token.withStack, context]));
                 }
 
                 var file = Twig.expression.parse.apply(this, [token.stack, innerContext]);


### PR DESCRIPTION
### Issue
While I was working on a PR which affects the contexts and merging them together, I kept running into issues with inconsistency in relation to how variables in the contexts were being stored. This resulted in it being difficult for two contexts to be merged together. It turned out to be an issue with how a new `ChildContext` stores passed variables on the prototype. Depending on how it is handled, the variables can become essentially hidden and not carry through when, for example, extending templates.

### Solution
This PR removes `ChildContext` completely, replacing it with a simple object which can be merged with other contexts using `Twig.lib.extend()`. The only thing that I can determine that `ChildContext` is used for, is to clone the original context so that any changes are isolated in the child. Every instance where `ChildContext` is used has been replaced with a call to `Twig.lib.copy()` which returns a new simple object with the same variables.

### Considerations
This would make working with the contexts much simpler, but I may be missing some details as to why `ChildContext` was created in the first place. I would greatly appreciate any background on it which would improve this PR or point out why `ChildContext` is needed.