### PR TITLE
Allow the `not` unary to be used more widely in expressions

### DIFF
--- a/src/twig.expression.js
+++ b/src/twig.expression.js
@@ -83,7 +83,8 @@ module.exports = function (Twig) {
             Twig.expression.type.parameter.start,
             Twig.expression.type.array.start,
             Twig.expression.type.object.start,
-            Twig.expression.type.subexpression.start
+            Twig.expression.type.subexpression.start,
+            Twig.expression.type.operator.unary
         ]
     };
 
@@ -199,7 +200,7 @@ module.exports = function (Twig) {
             // Match any of ?:, +, *, /, -, %, ~, <, <=, >, >=, !=, ==, **, ?, :, and, b-and, or, b-or, b-xor, in, not in
             // and, or, in, not in can be followed by a space or parenthesis
             regex: /(^\?\:|^(b\-and)|^(b\-or)|^(b\-xor)|^[\+\-~%\?]|^[\:](?!\d\])|^[!=]==?|^[!<>]=?|^\*\*?|^\/\/?|^(and)[\(|\s+]|^(or)[\(|\s+]|^(in)[\(|\s+]|^(not in)[\(|\s+]|^\.\.)/,
-            next: Twig.expression.set.expressions.concat([Twig.expression.type.operator.unary]),
+            next: Twig.expression.set.expressions,
             transform: function(match, tokens) {
                 switch(match[0]) {
                     case 'and(':

--- a/test/test.core.js
+++ b/test/test.core.js
@@ -167,6 +167,9 @@ describe("Twig.js Core ->", function() {
          twig({data: '{{ [1,2 ,1+2 ] }}'}).render().should.equal("1,2,3" );
          twig({data: '{{ [1,2 ,3 , "-", [4,5, 6] ] }}'}).render({val: 4}).should.equal("1,2,3,-,4,5,6" );
          twig({data: '{{ [a,b ,(1+2) * a ] }}'}).render({a:1,b:2}).should.equal("1,2,3" );
+
+         twig({data: '{{ [not a, b] }}'}).render({a: false, b: true}).should.equal("true,true");
+         twig({data: '{{ [a, not b] }}'}).render({a: true, b: false}).should.equal("true,true");
     });
     it("should be able to output variables", function() {
          twig({data: '{{ orp }}'}).render({ orp: "test"}).should.equal("test");

--- a/test/test.expressions.js
+++ b/test/test.expressions.js
@@ -250,6 +250,36 @@ describe("Twig.js Expressions ->", function() {
             test_template = twig({data: '{{ a or not b }}'});
             test_template.render({a: false, b: false}).should.equal('true');
             test_template.render({a: false, b: true}).should.equal('false');
+
+            test_template = twig({data: '{{ a or not not b }}'});
+            test_template.render({a: false, b: true}).should.equal('true');
+            test_template.render({a: false, b: false}).should.equal('false');
+        });
+        it("should support boolean not in parentheses", function() {
+            var test_template = twig({data: '{{ (test1 or test2) and test3 }}'});
+            test_template.render({test1: true, test2: false, test3: true}).should.equal("true");
+            test_template.render({test1: false, test2: false, test3: true}).should.equal("false");
+            test_template.render({test1: true, test2: false, test3: false}).should.equal("false");
+
+            var test_template = twig({data: '{{ (test1 or test2) and not test3 }}'});
+            test_template.render({test1: true, test2: false, test3: false}).should.equal("true");
+            test_template.render({test1: false, test2: false, test3: false}).should.equal("false");
+            test_template.render({test1: true, test2: false, test3: true}).should.equal("false");
+
+            var test_template = twig({data: '{{ (not test1 or test2) and test3 }}'});
+            test_template.render({test1: false, test2: false, test3: true}).should.equal("true");
+            test_template.render({test1: true, test2: false, test3: true}).should.equal("false");
+            test_template.render({test1: false, test2: false, test3: false}).should.equal("false");
+
+            var test_template = twig({data: '{{ (test1 or not test2) and test3 }}'});
+            test_template.render({test1: true, test2: true, test3: true}).should.equal("true");
+            test_template.render({test1: false, test2: true, test3: true}).should.equal("false");
+            test_template.render({test1: true, test2: true, test3: false}).should.equal("false");
+
+            var test_template = twig({data: '{{ (not test1 or not test2) and test3 }}'});
+            test_template.render({test1: false, test2: true, test3: true}).should.equal("true");
+            test_template.render({test1: true, test2: true, test3: true}).should.equal("false");
+            test_template.render({test1: false, test2: true, test3: false}).should.equal("false");
         });
 
         it("should correctly cast arrays", function () {
@@ -359,6 +389,9 @@ describe("Twig.js Expressions ->", function() {
 
             test_template = twig({data: '{{ {(foo): "value"}.bar }}'});
             test_template.render({foo: 'bar'}).should.equal('value');
+
+            test_template = twig({data: '{{ {(not foo): "value"}.true }}'});
+            test_template.render({foo: false}).should.equal('value');
         });
 
         it("should not corrupt the stack when accessing a property of an undefined object", function() {


### PR DESCRIPTION
Before you could not use the `not` unary in the first position in an expression.
Tests included.