### PR TITLE
Fix handling of relative paths in the `importFile` function

### DIFF
--- a/src/twig.core.js
+++ b/src/twig.core.js
@@ -1226,7 +1226,7 @@ module.exports = function (Twig) {
     Twig.Template.prototype.importFile = function(file) {
         var url, sub_template;
         if (!this.url && this.options.allowInlineIncludes) {
-            file = this.path ? this.path + '/' + file : file;
+            file = this.path ? Twig.path.parsePath(this, file) : file;
             sub_template = Twig.Templates.load(file);
 
             if (!sub_template) {


### PR DESCRIPTION
- This was incorrectly implemented in #264.
- A later call to `Twig.path.parsePath` in the `render` function generates the correct file path after `importFile` failed to do so, but not before an error would be thrown.

If you look back over previous Travis CI logs you can see the test `Twig.js Blocks -> block shorthand -> should overload blocks from an extended template using shorthand syntax` in `test.block.js` would pass, [but a couple errors would still be emitted](https://travis-ci.org/twigjs/twig.js/jobs/134087980#L1373-L1429).