### PR TITLE
Fix issue #440 - Object methods lose context when called

### DIFF
--- a/src/twig.expression.js
+++ b/src/twig.expression.js
@@ -850,7 +850,7 @@ module.exports = function (Twig) {
                 }
 
                 // When resolving an expression we need to pass next_token in case the expression is a function
-                stack.push(Twig.expression.resolve.apply(this, [value, context, params, next_token]));
+                stack.push(Twig.expression.resolve.apply(this, [value, context, params, next_token, object]));
             }
         },
         {
@@ -948,7 +948,7 @@ module.exports = function (Twig) {
      * @param {string} key The context object key.
      * @param {Object} context The render context.
      */
-    Twig.expression.resolve = function(value, context, params, next_token) {
+    Twig.expression.resolve = function(value, context, params, next_token, object) {
         if (typeof value == 'function') {
             /*
             If value is a function, it will have been impossible during the compile stage to determine that a following
@@ -968,7 +968,7 @@ module.exports = function (Twig) {
                 //Clean up the parentheses tokens on the next loop
                 next_token.cleanup = true;
             }
-            return value.apply(context, params || []);
+            return value.apply(object || context, params || []);
         } else {
             return value;
         }

--- a/test/test.functions.js
+++ b/test/test.functions.js
@@ -76,22 +76,24 @@ describe("Twig.js Functions ->", function() {
             data: '{{ obj.value }}'
         }).render({
             obj: {
+                test: "value",
                  value: function() {
-                    return "test";
+                    return this.test;
                 }
             }
-        }).should.equal("test");
+        }).should.equal("value");
     });
     it("should execute functions passed as context object parameters with arguments", function() {
         twig({
             data: '{{ obj.value(1, "test") }}'
         }).render({
             obj: {
+                test: "value",
                  value: function(a, b, c) {
-                    return a + "-" + b + "-" + (c===undefined?"true":"false");
+                    return a + "-" + b + "-" + this.test + '-' + (c===undefined?"true":"false");
                 }
             }
-        }).should.equal("1-test-true");
+        }).should.equal("1-test-value-true");
     });
     
     it("should execute functions passed as context object parameters", function() {


### PR DESCRIPTION
This PR fix the issue #440 by scoping functions call to the belonging object (if any) or to the context. Functions tests suite has also been improved to include object context test case.