### PR TITLE
Asynchronous rendering and function/filter promises

### DIFF
--- a/ASYNC.md
+++ b/ASYNC.md
@@ -1,0 +1,218 @@
+# Twig Asynchronous Rendering
+
+## Synchronous promises
+
+The asynchronous behaviour of Twig.js relies on promises, in order to support both the synchronous and asynchronous behaviour there is an internal promise implementation that runs fully synchronous.
+
+The internal implementation of promises does not use `setTimeout` to run through the promise chain, but instead synchronously runs through the promise chain.
+
+The different promise implementations can be mixed, synchronous behaviour however is no longer guaranteed as soon as the regular promise implementation is run.
+
+### Examples
+
+**Internal (synchronous) implementation**
+
+[Internal implementation](https://github.com/JorgenEvens/twig.js/tree/master/src/twig.async.js#L40)
+
+```javascript
+console.log('start');
+Twig.Promise.resolve('1')
+.then(function(v) {
+    console.log(v);
+    return '2';
+})
+.then(function(v) {
+    console.log(v);
+});
+console.log('stop');
+
+/**
+ * Prints to the console:
+ * start
+ * 1
+ * 2
+ * stop
+ */
+```
+
+**Regular / native promises**
+
+Implementations such as the native promises or [bluebird](http://bluebirdjs.com/docs/getting-started.html) promises.
+
+```javascript
+console.log('start');
+Promise.resolve('1')
+.then(function(v) {
+    console.log(v);
+    return '2';
+})
+.then(function(v) {
+    console.log(v);
+});
+console.log('stop');
+
+/**
+ * Prints to the console:
+ * start
+ * stop
+ * 1
+ * 2
+ */
+```
+
+**Mixing promises**
+
+```javascript
+console.log('start');
+Twig.Promise.resolve('1')
+.then(function(v) {
+    console.log(v);
+    return Promise.resolve('2');
+})
+.then(function(v) {
+    console.log(v);
+});
+console.log('stop');
+
+/**
+ * Prints to the console:
+ * start
+ * 1
+ * stop
+ * 2
+ */
+```
+
+
+## Async helpers
+
+To preserve the correct order of execution there is an implemenation of `Twig.forEach()` that waits any promises returned from the callback before executing the next iteration of the loop. If no promise is returned the next iteration is invoked immediately.
+
+```javascript
+var arr = new Array(5);
+
+Twig.async.forEach(arr, function(value, index) {
+    console.log(index);
+
+    if (index % 2 == 0)
+        return index;
+
+    return Promise.resolve(index);
+})
+.then(function() {
+    console.log('finished');
+});
+
+/**
+ * Prints to the console:
+ * 0
+ * 1
+ * 2
+ * 3
+ * 4
+ * finished
+ */
+```
+
+## Switching render mode
+
+The rendering mode of Twig.js internally is determined by the `allow_async` argument that can be passed into `Twig.expression.parse`, `Twig.logic.parse`, `Twig.parse` and `Twig.Template.render`. Detecting if at any point code runs asynchronously is explained in [detecting asynchronous behaviour](#detecting-asynchronous-behaviour).
+
+For the end user switching between synchronous and asynchronous is as simple as using a different method on the template instance.
+
+**Render template synchronously**
+
+```javascript
+var output = twig({
+    data: 'a {{value}}'
+}).render({
+    value: 'test'
+});
+
+/**
+ * Prints to the console:
+ * a test
+ */
+```
+
+**Render template asynchronously**
+
+```javascript
+var template = twig({
+    data: 'a {{value}}'
+}).renderAsync({
+    value: 'test'
+})
+.then(function(output) {
+    console.log(output);
+});
+
+/**
+ * Prints to the console:
+ * a test
+ */
+```
+
+## Detecting asynchronous behaviour
+
+The pattern used to detect asynchronous behaviour is the same everywhere it is used and follows a simple pattern.
+
+1. Set a variable `is_async = true`
+2. Run the promise chain that might contain some asynchronous behaviour.
+3. As the last method in the promise chain set `is_async = false`
+4. Underneath the promise chain test whether `is_async` is `true`
+
+This pattern works because the last method in the chain will be executed in the next run of the eventloop (`setTimeout`/`setImmediate`).
+
+### Examples
+
+**Synchronous promises only**
+
+```javascript
+var is_async = true;
+
+Twig.Promise.resolve()
+.then(function() {
+    // We run our work in here such to allow for asynchronous work
+    // This example is fully synchronous
+    return 'hello world';
+})
+.then(function() {
+    is_async = false;
+});
+
+if (is_async)
+    console.log('method ran asynchronous');
+
+console.log('method ran synchronous');
+
+/**
+ * Prints to the console:
+ * method ran synchronous
+ */
+```
+
+**Mixed promises**
+
+```javascript
+var is_async = true;
+
+Twig.Promise.resolve()
+.then(function() {
+    // We run our work in here such to allow for asynchronous work
+    return Promise.resolve('hello world');
+})
+.then(function() {
+    is_async = false;
+});
+
+if (is_async)
+    console.log('method ran asynchronous');
+
+console.log('method ran synchronous');
+
+/**
+ * Prints to the console:
+ * method ran asynchronous
+ */
+```

--- a/src/twig.async.js
+++ b/src/twig.async.js
@@ -1,0 +1,186 @@
+// ## twig.async.js
+//
+// This file handles asynchronous tasks within twig.
+module.exports = function (Twig) {
+    "use strict";
+
+    Twig.async = {};
+
+    Twig.isPromise = function(obj) {
+        return obj && (typeof obj.then == 'function');
+    }
+
+    /**
+     * An alternate implementation of a Promise that does not follow
+     * the spec, but instead works fully synchronous while still being
+     * thenable.
+     *
+     * The promises can be mixed with regular promises at which point
+     * the synchronous behaviour is lost.
+     */
+    Twig.Promise = function(executor) {
+        // State
+        var state = 'unknown';
+        var value = null;
+        var handlers = null;
+
+        function changeState(newState, v) {
+            state = newState;
+            value = v;
+            notify();
+        };
+        function onResolve(v) { changeState('resolve', v); }
+        function onReject(e) { changeState('reject', e); }
+
+        function notify() {
+            if (!handlers) return;
+
+            Twig.forEach(handlers, function(h) {
+                append(h.resolve, h.reject);
+            });
+            handlers = null;
+        }
+
+        function append(onResolved, onRejected) {
+            var h = {
+                resolve: onResolved,
+                reject: onRejected
+            };
+
+            // The promise has yet to be rejected or resolved.
+            if (state == 'unknown') {
+                handlers = handlers || [];
+                return handlers.push(h);
+            }
+
+            // The state has been changed to either resolve, or reject
+            // which means we should call the handler.
+            if (h[state])
+                h[state](value);
+        }
+
+        function run(fn, resolve, reject) {
+            var done = false;
+            try {
+                fn(function(v) {
+                    if (done) return;
+                    done = true;
+                    resolve(v);
+                }, function(e) {
+                    if (done) return;
+                    done = true;
+                    reject(e);
+                });
+            } catch(e) {
+                done = true;
+                reject(e);
+            }
+        }
+
+        function ready(result) {
+            try {
+                if (!Twig.isPromise(result)) {
+                    return onResolve(result);
+                }
+
+                run(result.then.bind(result), ready, onReject);
+            } catch (e) {
+                onReject(e);
+            }
+        }
+
+        run(executor, ready, onReject);
+
+        return {
+            then: function(onResolved, onRejected) {
+                var hasResolved = typeof onResolved == 'function';
+                var hasRejected = typeof onRejected == 'function';
+
+                return new Twig.Promise(function(resolve, reject) {
+                    append(function(result) {
+                        if (hasResolved) {
+                            try {
+                                resolve(onResolved(result));
+                            } catch (e) {
+                                reject(e);
+                            }
+                        } else {
+                            resolve(result);
+                        }
+                    }, function(err) {
+                        if (hasRejected) {
+                            try {
+                                resolve(onRejected(err));
+                            } catch (e) {
+                                reject(e);
+                            }
+                        } else {
+                            reject(err);
+                        }
+                    });
+                });
+            },
+            catch: function(onRejected) {
+                return this.then(null, onRejected);
+            }
+        };
+    }
+
+    Twig.Promise.resolve = function(value) {
+        return new Twig.Promise(function(resolve) {
+            resolve(value);
+        });
+    }
+
+    Twig.Promise.reject = function(e) {
+        return new Twig.Promise(function(resolve, reject) {
+            reject(e);
+        });
+    }
+
+    /**
+    * Go over each item in a fashion compatible with Twig.forEach,
+    * allow the function to return a promise or call the third argument
+    * to signal it is finished.
+    *
+    * Each item in the array will be called sequentially.
+    */
+    Twig.async.forEach = function each(arr, callback) {
+        var arg_index = 0;
+        var is_async = true;
+        var callbacks = {};
+        var promise = new Twig.Promise(function(resolve, reject) {
+            callbacks = {
+                resolve: resolve,
+                reject: reject
+            };
+        });
+
+        function fail(err) {
+            callbacks.reject(err);
+        }
+
+        function next(value) {
+            if (!Twig.isPromise(value))
+                return iterate();
+
+            value.then(next, fail);
+        }
+
+        function iterate() {
+            var index = arg_index++;
+
+            if (index == arr.length) {
+                callbacks.resolve();
+                return;
+            }
+
+            next(callback(arr[index], index));
+        }
+
+        iterate();
+
+        return promise;
+    };
+
+};

--- a/src/twig.core.js
+++ b/src/twig.core.js
@@ -736,7 +736,20 @@ module.exports = function (Twig) {
      * @return {string} The parsed template.
      */
     Twig.parse = function (tokens, context, allow_async) {
-        var that = this;
+        var that = this,
+            output = [],
+
+            // Store any error that might be thrown by the promise chain.
+            err = null,
+
+            // This will be set to is_async if template renders synchronously
+            is_async = true,
+            promise = null,
+
+            // Track logic chains
+            chain = true;
+
+
         function handleException(ex) {
             if (that.options.rethrow) {
                 throw ex;
@@ -755,71 +768,75 @@ module.exports = function (Twig) {
             }
         }
 
-        try {
-            var output = [],
-                is_async = true,
-                promise = null,
-                // Track logic chains
-                chain = true;
+        promise = Twig.async.forEach(tokens, function parseToken(token) {
+            Twig.log.debug("Twig.parse: ", "Parsing token: ", token);
 
-            promise = Twig.async.forEach(tokens, function parseToken(token) {
-                Twig.log.debug("Twig.parse: ", "Parsing token: ", token);
+            switch (token.type) {
+                case Twig.token.type.raw:
+                    output.push(Twig.filters.raw(token.value));
+                    break;
 
-                switch (token.type) {
-                    case Twig.token.type.raw:
-                        output.push(Twig.filters.raw(token.value));
-                        break;
+                case Twig.token.type.logic:
+                    var logic_token = token.token;
 
-                    case Twig.token.type.logic:
-                        var logic_token = token.token;
+                    return Twig.logic.parseAsync.apply(that, [logic_token, context, chain])
+                    .then(function(logic) {
+                        if (logic.chain !== undefined) {
+                            chain = logic.chain;
+                        }
+                        if (logic.context !== undefined) {
+                            context = logic.context;
+                        }
+                        if (logic.output !== undefined) {
+                            output.push(logic.output);
+                        }
+                    });
+                    break;
 
-                        return Twig.Promise.resolve(Twig.logic.parse.apply(that, [logic_token, context, chain, allow_async]))
-                        .then(function(logic) {
-                            if (logic.chain !== undefined) {
-                                chain = logic.chain;
-                            }
-                            if (logic.context !== undefined) {
-                                context = logic.context;
-                            }
-                            if (logic.output !== undefined) {
-                                output.push(logic.output);
-                            }
-                        });
-                        break;
+                case Twig.token.type.comment:
+                    // Do nothing, comments should be ignored
+                    break;
 
-                    case Twig.token.type.comment:
-                        // Do nothing, comments should be ignored
-                        break;
-
-                    //Fall through whitespace to output
-                    case Twig.token.type.output_whitespace_pre:
-                    case Twig.token.type.output_whitespace_post:
-                    case Twig.token.type.output_whitespace_both:
-                    case Twig.token.type.output:
-                        Twig.log.debug("Twig.parse: ", "Output token: ", token.stack);
-                        // Parse the given expression in the given context
-                        return Twig.expression.parseAsync.apply(that, [token.stack, context])
-                        .then(function(o) {
-                            output.push(o);
-                        });
-                }
-            })
-            .then(function() {
-                output = Twig.output.apply(that, [output]);
-                is_async = false;
-                return output;
-            });
-
-            if (allow_async)
-                return promise;
-
-            if (is_async)
-                throw new Error('You are using Twig.js in sync mode in combination with async extensions.');
-
+                //Fall through whitespace to output
+                case Twig.token.type.output_whitespace_pre:
+                case Twig.token.type.output_whitespace_post:
+                case Twig.token.type.output_whitespace_both:
+                case Twig.token.type.output:
+                    Twig.log.debug("Twig.parse: ", "Output token: ", token.stack);
+                    // Parse the given expression in the given context
+                    return Twig.expression.parseAsync.apply(that, [token.stack, context])
+                    .then(function(o) {
+                        output.push(o);
+                    });
+            }
+        })
+        .then(function() {
+            output = Twig.output.apply(that, [output]);
+            is_async = false;
             return output;
-        } catch (ex) {
-            handleException(ex);
-        }
+        })
+        .catch(function(e) {
+            if (allow_async)
+                handleException(e);
+
+            err = e;
+        });
+
+        // If `allow_async` we will always return a promise since we do not
+        // know in advance if we are going to run asynchronously or not.
+        if (allow_async)
+            return promise;
+
+        // Handle errors here if we fail synchronously.
+        if (err !== null)
+            return handleException(err);
+
+        // If `allow_async` is not true we should not allow the user
+        // to use asynchronous functions or filters.
+        if (is_async)
+            throw new Twig.Error('You are using Twig.js in sync mode in combination with async extensions.');
+
+        return output;
     };
 
     /**
@@ -1187,10 +1204,19 @@ module.exports = function (Twig) {
         this.extend = null;
     };
 
-    Twig.Template.prototype.renderAsync = function (context, params) {
+    Twig.Template.prototype.render = function (context, params, allow_async) {
         params = params || {};
 
-        var output,
+        var that = this,
+
+            // Store any error that might be thrown by the promise chain.
+            err = null,
+
+            // This will be set to is_async if template renders synchronously
+            is_async = true,
+            promise = null,
+
+            result,
             url;
 
         this.context = context || {};
@@ -1205,110 +1231,76 @@ module.exports = function (Twig) {
         }
 
         var cb = function(output) {
-
             // Does this template extend another
-            if (this.extend) {
+            if (that.extend) {
                 var ext_template;
 
                 // check if the template is provided inline
-                if ( this.options.allowInlineIncludes ) {
-                    ext_template = Twig.Templates.load(this.extend);
+                if ( that.options.allowInlineIncludes ) {
+                    ext_template = Twig.Templates.load(that.extend);
                     if ( ext_template ) {
-                        ext_template.options = this.options;
+                        ext_template.options = that.options;
                     }
                 }
 
                 // check for the template file via include
                 if (!ext_template) {
-                    url = Twig.path.parsePath(this, this.extend);
+                    url = Twig.path.parsePath(that, that.extend);
 
                     ext_template = Twig.Templates.loadRemote(url, {
-                        method: this.getLoaderMethod(),
-                        base: this.base,
+                        method: that.getLoaderMethod(),
+                        base: that.base,
                         async:  false,
                         id:     url,
-                        options: this.options
+                        options: that.options
                     });
                 }
 
-                this.parent = ext_template;
+                that.parent = ext_template;
 
-                return this.parent.renderAsync(this.context, {
-                    blocks: this.blocks
+                return that.parent.renderAsync(that.context, {
+                    blocks: that.blocks
                 });
             }
 
             if (params.output == 'blocks') {
-                return this.blocks;
+                return that.blocks;
             } else if (params.output == 'macros') {
-                return this.macros;
+                return that.macros;
             } else {
                 return output;
             }
-        }.bind(this);
+        };
 
-        return Twig.parse.apply(this, [this.tokens, this.context, true])
-        .then(cb);
-    };
+        promise = Twig.parseAsync.apply(this, [this.tokens, this.context])
+        .then(cb)
+        .then(function(v) {
+            is_async = false;
+            result = v;
+            return v;
+        })
+        .catch(function(e) {
+            if (allow_async)
+                throw e;
 
-    Twig.Template.prototype.render = function (context, params) {
-        params = params || {};
+            err = e;
+        })
 
-        var output,
-            url;
+        // If `allow_async` we will always return a promise since we do not
+        // know in advance if we are going to run asynchronously or not.
+        if (allow_async)
+            return promise;
 
-        this.context = context || {};
+        // Handle errors here if we fail synchronously.
+        if (err !== null)
+            throw err;
 
-        // Clear any previous state
-        this.reset();
-        if (params.blocks) {
-            this.blocks = params.blocks;
-        }
-        if (params.macros) {
-            this.macros = params.macros;
-        }
+        // If `allow_async` is not true we should not allow the user
+        // to use asynchronous functions or filters.
+        if (is_async)
+            throw new Twig.Error('You are using Twig.js in sync mode in combination with async extensions.');
 
-        output = Twig.parse.apply(this, [this.tokens, this.context]);
-
-        // Does this template extend another
-        if (this.extend) {
-            var ext_template;
-
-            // check if the template is provided inline
-            if ( this.options.allowInlineIncludes ) {
-                ext_template = Twig.Templates.load(this.extend);
-                if ( ext_template ) {
-                    ext_template.options = this.options;
-                }
-            }
-
-            // check for the template file via include
-            if (!ext_template) {
-                url = Twig.path.parsePath(this, this.extend);
-
-                ext_template = Twig.Templates.loadRemote(url, {
-                    method: this.getLoaderMethod(),
-                    base: this.base,
-                    async:  false,
-                    id:     url,
-                    options: this.options
-                });
-            }
-
-            this.parent = ext_template;
-
-            return this.parent.render(this.context, {
-                blocks: this.blocks
-            });
-        }
-
-        if (params.output == 'blocks') {
-            return this.blocks;
-        } else if (params.output == 'macros') {
-            return this.macros;
-        } else {
-            return output;
-        }
+        return result;
     };
 
     Twig.Template.prototype.importFile = function(file) {

--- a/src/twig.expression.js
+++ b/src/twig.expression.js
@@ -1314,7 +1314,14 @@ module.exports = function (Twig) {
             }
 
             next(result);
-        }, function(next) {
+        }, function(err, next) {
+            if (err) {
+                if (!has_callback)
+                    throw err;
+
+                callback(Twig.Promise.reject(err));
+                return;
+            }
             //Check every fixup and remove "key" as long as they still have "params". This covers the use case where
             //a ":" operator is used in a loop with a "(expression):" statement. We need to be able to evaluate the expression
             Twig.forEach(loop_token_fixups, function (loop_token_fixup) {
@@ -1354,7 +1361,7 @@ module.exports = function (Twig) {
 
     Twig.expression.parseAsync = function (tokens, context, tokens_are_parameters) {
         var that = this;
-        return new Twig.Promise(function(resolve, reject) {
+        return new Twig.Promise(function(resolve) {
             Twig.expression.parse.apply(that, [tokens, context, tokens_are_parameters, resolve]);
         });
     }

--- a/src/twig.expression.js
+++ b/src/twig.expression.js
@@ -756,10 +756,15 @@ module.exports = function (Twig) {
                 output.push(token);
             },
             parse: function(token, stack, context) {
-                var input = stack.pop();
+                var that = this,
+                    input = stack.pop();
 
-                return parseParams(this, token.params, context, function(params) {
-                    stack.push(Twig.filter.apply(this, [token.value, input, params]));
+                return parseParams(this, token.params, context)
+                .then(function(params) {
+                    return Twig.filter.apply(that, [token.value, input, params]);
+                })
+                .then(function(value) {
+                    stack.push(value);
                 });
             }
         },

--- a/src/twig.expression.js
+++ b/src/twig.expression.js
@@ -1340,15 +1340,11 @@ module.exports = function (Twig) {
             return promise;
 
         if (is_async)
-            throw new Error('You are using Twig.js in sync mode in combination with async extensions.');
+            throw new Twig.Error('You are using Twig.js in sync mode in combination with async extensions.');
 
         // Pop the final value off the stack
         return stack.pop();
     };
-
-    Twig.expression.parseAsync = function (tokens, context, tokens_are_parameters) {
-        return Twig.expression.parse.apply(this, [tokens, context, tokens_are_parameters, true]);
-    }
 
     return Twig;
 

--- a/src/twig.js
+++ b/src/twig.js
@@ -11,6 +11,7 @@ var Twig = {
 };
 
 require('./twig.core')(Twig);
+require('./twig.async')(Twig);
 require('./twig.compiler')(Twig);
 require('./twig.expression')(Twig);
 require('./twig.filters')(Twig);

--- a/src/twig.js
+++ b/src/twig.js
@@ -11,7 +11,6 @@ var Twig = {
 };
 
 require('./twig.core')(Twig);
-require('./twig.async')(Twig);
 require('./twig.compiler')(Twig);
 require('./twig.expression')(Twig);
 require('./twig.filters')(Twig);
@@ -24,6 +23,7 @@ require('./twig.parser.source')(Twig);
 require('./twig.parser.twig')(Twig);
 require('./twig.path')(Twig);
 require('./twig.tests')(Twig);
+require('./twig.async')(Twig);
 require('./twig.exports')(Twig);
 
 module.exports = Twig.exports;

--- a/test/test.async.js
+++ b/test/test.async.js
@@ -1,0 +1,121 @@
+var Twig = Twig || require("../twig"),
+    twig = twig || Twig.twig;
+
+describe("Twig.js Async ->", function() {
+
+    // Add some test functions to work with
+    Twig.extendFunction("echoAsync", function(a) {
+        return Promise.resolve(a);
+    });
+
+    Twig.extendFilter('asyncUpper', function(txt) {
+        return Promise.resolve(txt.toUpperCase());
+    });
+
+    Twig.extendFilter('rejectAsync', function(txt) {
+        return Promise.reject(new Error('async error test'));
+    });
+
+    it("should throw when detecting async behaviour in sync mode", function() {
+        try {
+            return twig({
+                data: '{{ echoAsync("hello world") }}'
+            }).render();
+        } catch(err) {
+            err.message.should.equal('You are using Twig.js in sync mode in combination with async extensions.');
+        }
+    });
+
+    describe("Functions ->", function() {
+        it("should handle functions that return promises", function() {
+            return twig({
+                data: '{{ echoAsync("hello world") }}'
+            }).renderAsync()
+            .then(function(output) {
+                output.should.equal("hello world");
+            });
+        });
+        it("should handle functions that return rejected promises", function() {
+            return twig({
+                data: '{{ rejectAsync("hello world") }}',
+                rethrow: true
+            }).renderAsync({
+                rejectAsync: function() {
+                    return Promise.reject(new Error('async error test'));
+                }
+            })
+            .then(function(output) {
+                throw new Error('should not resolve');
+            }, function(err) {
+                err.message.should.equal('async error test');
+            });
+        });
+    });
+
+    describe("Filters ->", function() {
+        it("should handle filters that return promises", function() {
+            return twig({
+                data: '{{ "hello world"|asyncUpper }}'
+            }).renderAsync()
+            .then(function(output) {
+                output.should.equal("HELLO WORLD");
+            });
+        });
+        it("should handle filters that return rejected promises", function() {
+            return twig({
+                data: '{{ "hello world"|rejectAsync }}',
+                rethrow: true
+            }).renderAsync()
+            .then(function(output) {
+                throw new Error('should not resolve');
+            }, function(err) {
+                err.message.should.equal('async error test');
+            });
+        });
+    })
+
+    describe("Logic ->", function() {
+        it("should handle logic containing async functions", function() {
+            return twig({
+                data: 'hello{% if incrAsync(10) > 10 %} world{% endif %}'
+            }).renderAsync({
+                incrAsync: function(nr) {
+                    return Promise.resolve(nr + 1);
+                }
+            })
+            .then(function(output) {
+                output.should.equal("hello world");
+            });
+        });
+        it("should set variables to return value of promise", function() {
+            return twig({
+                data: '{% set name = readName() %}hello {{ name }}',
+                rethrow: true
+            }).renderAsync({
+                readName: function() {
+                    return Promise.resolve('john');
+                }
+            })
+            .then(function(output) {
+                output.should.equal('hello john');
+            });
+        });
+    });
+
+    describe("Macros ->", function() {
+        it("should handle macros with async content correctly", function() {
+            var tpl = '{% macro test(asyncIn, syncIn) %}{{asyncIn}}-{{syncIn}}{% endmacro %}' +
+                '{% import _self as m %}' +
+                '{{ m.test(echoAsync("hello"), "world") }}';
+
+            return twig({
+                data: tpl
+            })
+            .renderAsync()
+            .then(function(output) {
+                output.should.equal('hello-world');
+            });
+        });
+    });
+
+});

--- a/test/test.filters.js
+++ b/test/test.filters.js
@@ -733,29 +733,4 @@ describe("Twig.js Filters ->", function() {
         var test_template = twig({data: '{{ ["a", "b", "c"]|keys|reverse }}' });
         test_template.render().should.equal("2,1,0");
     });
-    it("should handle filters that return promises", function() {
-        Twig.extendFilter('asyncUpper', function(txt) {
-            return Promise.resolve(txt.toUpperCase());
-        });
-        return twig({
-            data: '{{ "hello world"|asyncUpper }}'
-        }).renderAsync({})
-        .then(function(output) {
-            output.should.equal("HELLO WORLD");
-        });
-    });
-    it("should handle filters that return rejected promises", function() {
-        Twig.extendFilter('asyncUpper', function(txt) {
-            return Promise.reject(new Error('async error test'));
-        });
-        return twig({
-            data: '{{ "hello world"|asyncUpper }}',
-            rethrow: true
-        }).renderAsync({})
-        .then(function(output) {
-            throw new Error('should not resolve');
-        }, function(err) {
-            err.message.should.equal('async error test');
-        });
-    });
 });

--- a/test/test.filters.js
+++ b/test/test.filters.js
@@ -749,7 +749,8 @@ describe("Twig.js Filters ->", function() {
             return Promise.reject(new Error('async error test'));
         });
         return twig({
-            data: '{{ "hello world"|asyncUpper }}'
+            data: '{{ "hello world"|asyncUpper }}',
+            rethrow: true
         }).renderAsync({})
         .then(function(output) {
             throw new Error('should not resolve');

--- a/test/test.filters.js
+++ b/test/test.filters.js
@@ -733,4 +733,15 @@ describe("Twig.js Filters ->", function() {
         var test_template = twig({data: '{{ ["a", "b", "c"]|keys|reverse }}' });
         test_template.render().should.equal("2,1,0");
     });
+    it("should handle filters that return promises", function() {
+        Twig.extendFilter('asyncUpper', function(txt) {
+            return Promise.resolve(txt.toUpperCase());
+        });
+        return twig({
+            data: '{{ "hello world"|asyncUpper }}'
+        }).renderAsync({})
+        .then(function(output) {
+            output.should.equal("HELLO WORLD");
+        });
+    });
 });

--- a/test/test.filters.js
+++ b/test/test.filters.js
@@ -744,4 +744,17 @@ describe("Twig.js Filters ->", function() {
             output.should.equal("HELLO WORLD");
         });
     });
+    it("should handle filters that return rejected promises", function() {
+        Twig.extendFilter('asyncUpper', function(txt) {
+            return Promise.reject(new Error('async error test'));
+        });
+        return twig({
+            data: '{{ "hello world"|asyncUpper }}'
+        }).renderAsync({})
+        .then(function(output) {
+            throw new Error('should not resolve');
+        }, function(err) {
+            err.message.should.equal('async error test');
+        });
+    });
 });

--- a/test/test.functions.js
+++ b/test/test.functions.js
@@ -12,7 +12,7 @@ describe("Twig.js Functions ->", function() {
     Twig.extendFunction("list", function() {
         return Array.prototype.slice.call(arguments);
     });
-    
+
     it("should allow you to define a function", function() {
         twig({data: '{{ square(a) }}'}).render({a:4}).should.equal("16");
     });
@@ -31,7 +31,7 @@ describe("Twig.js Functions ->", function() {
     it("should work with boolean operations", function() {
         twig({data: '{% if echo(true) or echo(false) %}yes{% endif %}'}).render().should.equal("yes");
     });
-    
+
     it("should execute functions passed as context values", function() {
         twig({
             data: '{{ value }}'
@@ -70,7 +70,7 @@ describe("Twig.js Functions ->", function() {
             }
         }).should.equal("value");
     });
-    
+
     it("should execute functions passed as context object parameters", function() {
         twig({
             data: '{{ obj.value }}'
@@ -95,7 +95,7 @@ describe("Twig.js Functions ->", function() {
             }
         }).should.equal("1-test-value-true");
     });
-    
+
     it("should execute functions passed as context object parameters", function() {
         twig({
             data: '{{ obj["value"] }}'
@@ -118,10 +118,22 @@ describe("Twig.js Functions ->", function() {
             }
         }).should.equal("1-test-true");
     });
-    
-    
+    it("should handle functions that return promises", function() {
+        return twig({
+            data: '{{ asyncEcho("hello world") }}'
+        }).renderAsync({
+            asyncEcho: function(txt) {
+                return Promise.resolve(txt);
+            }
+        })
+        .then(function(output) {
+            output.should.equal("hello world");
+        });
+    });
+
+
     describe("Built-in Functions ->", function() {
-        describe("range ->", function() { 
+        describe("range ->", function() {
             it("should work over a range of numbers", function() {
                 twig({data: '{% for i in range(0, 3) %}{{ i }},{% endfor %}'}).render().should.equal("0,1,2,3,");
             });
@@ -131,24 +143,24 @@ describe("Twig.js Functions ->", function() {
             it("should work with an interval", function() {
                 twig({data: '{% for i in range(1, 15, 3) %}{{ i }},{% endfor %}'}).render().should.equal("1,4,7,10,13,");
             });
-			
+
             it("should work with .. invocation", function() {
                 twig({data: '{% for i in 0..3 %}{{ i }},{% endfor %}'}).render().should.equal("0,1,2,3,");
                 twig({data: '{% for i in "a" .. "c" %}{{ i }},{% endfor %}'}).render().should.equal("a,b,c,");
             });
         });
-        describe("cycle ->", function() { 
+        describe("cycle ->", function() {
             it("should cycle through an array of values", function() {
                 twig({data: '{% for i in range(0, 3) %}{{ cycle(["odd", "even"], i) }};{% endfor %}'}).render().should.equal("odd;even;odd;even;");
             });
         });
-        describe("date ->", function() { 
+        describe("date ->", function() {
             function pad(num) {return num<10?'0'+num:num;}
             function stringDate(date){
                 return pad(date.getDate()) + "/" + pad(date.getMonth()+1) + "/" + date.getFullYear()
                                          + " @ " + pad(date.getHours()) + ":" + pad(date.getMinutes()) + ":" + pad(date.getSeconds());
             }
-        
+
             it("should understand timestamps", function() {
                 var date = new Date(946706400 * 1000);
                 twig({data: '{{ date(946706400)|date("d/m/Y @ H:i:s") }}'}).render().should.equal(stringDate(date));
@@ -162,7 +174,7 @@ describe("Twig.js Functions ->", function() {
             });
             it("should understand exact dates", function() {
                 var date = new Date("June 20, 2010 UTC");
-            
+
                 twig({data: '{{ date("June 20, 2010 UTC")|date("d/m/Y @ H:i:s") }}'}).render().should.equal(stringDate(date));
             });
         });
@@ -210,31 +222,31 @@ describe("Twig.js Functions ->", function() {
         describe("attribute ->", function() {
             it("should access attribute of an object", function() {
                 twig({data: '{{ attribute(obj, key) }}' }).render({
-                    obj: { name: "Twig.js"}, 
+                    obj: { name: "Twig.js"},
                     key: "name"
                 })
                 .should.equal("Twig.js");
             });
 
             it("should call function of attribute of an object", function() {
-                twig({data: '{{ attribute(obj, key, params) }}' }).render({ 
+                twig({data: '{{ attribute(obj, key, params) }}' }).render({
                     obj: {
-                        name: function(first, last) { 
+                        name: function(first, last) {
                             return first+'.'+last;
-                        } 
+                        }
                     },
                     key: "name",
                     params: ['Twig', 'js']
                   })
                   .should.equal("Twig.js");
             });
-            
+
             it("should return undefined for missing attribute of an object", function() {
-                twig({data: '{{ attribute(obj, key, params) }}' }).render({ 
+                twig({data: '{{ attribute(obj, key, params) }}' }).render({
                     obj: {
-                        name: function(first, last) { 
+                        name: function(first, last) {
                             return first+'.'+last;
-                        } 
+                        }
                     },
                     key: "missing",
                     params: ['Twig', 'js']
@@ -243,19 +255,19 @@ describe("Twig.js Functions ->", function() {
             });
 
             it("should return element of an array", function() {
-                twig({data: '{{ attribute(arr, 0) }}' }).render({ 
+                twig({data: '{{ attribute(arr, 0) }}' }).render({
                     arr: ['Twig', 'js']
                   })
                   .should.equal("Twig");
             });
 
             it("should return undef for array beyond index size", function() {
-                twig({data: '{{ attribute(arr, 100) }}' }).render({ 
+                twig({data: '{{ attribute(arr, 100) }}' }).render({
                     arr: ['Twig', 'js']
                   })
                   .should.equal("");
             });
- 
+
         });
         describe("template_from_string ->", function() {
             it("should load a template from a string", function() {

--- a/test/test.functions.js
+++ b/test/test.functions.js
@@ -118,34 +118,6 @@ describe("Twig.js Functions ->", function() {
             }
         }).should.equal("1-test-true");
     });
-    it("should handle functions that return promises", function() {
-        return twig({
-            data: '{{ asyncEcho("hello world") }}'
-        }).renderAsync({
-            asyncEcho: function(txt) {
-                return Promise.resolve(txt);
-            }
-        })
-        .then(function(output) {
-            output.should.equal("hello world");
-        });
-    });
-    it("should handle functions that return rejected promises", function() {
-        return twig({
-            data: '{{ asyncEcho("hello world") }}',
-            rethrow: true
-        }).renderAsync({
-            asyncEcho: function() {
-                return Promise.reject(new Error('async error test'));
-            }
-        })
-        .then(function(output) {
-            throw new Error('should not resolve');
-        }, function(err) {
-            err.message.should.equal('async error test');
-        });
-    });
-
 
     describe("Built-in Functions ->", function() {
         describe("range ->", function() {

--- a/test/test.functions.js
+++ b/test/test.functions.js
@@ -130,6 +130,20 @@ describe("Twig.js Functions ->", function() {
             output.should.equal("hello world");
         });
     });
+    it("should handle functions that return rejected promises", function() {
+        return twig({
+            data: '{{ asyncEcho("hello world") }}'
+        }).renderAsync({
+            asyncEcho: function() {
+                return Promise.reject(new Error('async error test'));
+            }
+        })
+        .then(function(output) {
+            throw new Error('should not resolve');
+        }, function(err) {
+            err.message.should.equal('async error test');
+        });
+    });
 
 
     describe("Built-in Functions ->", function() {

--- a/test/test.functions.js
+++ b/test/test.functions.js
@@ -132,7 +132,8 @@ describe("Twig.js Functions ->", function() {
     });
     it("should handle functions that return rejected promises", function() {
         return twig({
-            data: '{{ asyncEcho("hello world") }}'
+            data: '{{ asyncEcho("hello world") }}',
+            rethrow: true
         }).renderAsync({
             asyncEcho: function() {
                 return Promise.reject(new Error('async error test'));


### PR DESCRIPTION
Allows for functions and filters to return promises and render asynchronously (https://github.com/twigjs/twig.js/issues/61).

I've tried to build this PR based on the discussions in the original issue and some offline discussions with @Gertt. The currently implementation tries to change as little of the existing code as possible, but I had to restructure the implementation of some `logic`/`expression` code such that it would behave correctly when used with promises.

Only the `Twig.expression.parse`, `Twig.expression.resolve`, `Twig.parse` and `Twig.Template.render` methods are truly aware of the fact that promises are used internally. If the flag `allow_async` is set these methods will allow functions and filters to behave asynchronously, otherwise it will throw as soon as the asynchronous behaviour is detected.

The original synchronous behaviour of Twig.js is preserved using a internal Promise implementation (`Twig.Promise`) that does not use `setTimeout` to call the `then` methods, in effect running all code synchronously. Since we can mix different implementation of promises (any thenable really), we can return regular promises from functions or filters at which time rendering will start to run asynchronously.

The external API should be left unchanged as far as I can tell. To allow for asynchronous rendering a user would use `template.renderAsync` which will return a promise.

Internally Twig.js should use the `Twig.expression.parseAsync`, `Twig.expression.resolveAsync`, `Twig.parseAsync` and `template.renderAsync` to ensure that every component is ready to receive a promise. These methods are shorthands for an easier transition that take the exact same arguments as the regular methods, but will automatically set the `allow_async` argument to true.

What are your thoughts on this? I'm happy to give this a few revisions if you'd like to try out some different things.

Some things that might improve readability of this PR:

- Viewing this PR without indendations highlight (adding `?w=1` to the URL). https://github.com/twigjs/twig.js/pull/457/files?w=1
- [ES6 arrow functions](http://babeljs.io/docs/plugins/transform-es2015-arrow-functions/), less `var that = this` and generally more concise methods inside of `.then(...)`. Depending on your target this would require `babel`.