### PR TITLE
Fix issue #463 - Test result is dependent on the name of the test file

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
   "devDependencies": {
     "chai": "^3.5.0",
     "mocha": "3.1.x",
+    "require-uncached": "^1.0.3",
     "should": "11.1.x",
     "sinon": "^1.17.6",
     "sinon-chai": "^2.8.0",

--- a/test/hooks.js
+++ b/test/hooks.js
@@ -1,0 +1,1 @@
+global.requireUncached = require('require-uncached');

--- a/test/test.async.js
+++ b/test/test.async.js
@@ -1,4 +1,4 @@
-var Twig = Twig || require("../twig"),
+var Twig = Twig || requireUncached("../twig"),
     twig = twig || Twig.twig;
 
 describe("Twig.js Async ->", function() {

--- a/test/test.block.js
+++ b/test/test.block.js
@@ -1,4 +1,4 @@
-var Twig = Twig || require("../twig"),
+var Twig = Twig || requireUncached("../twig"),
     twig = twig || Twig.twig;
 
 describe("Twig.js Blocks ->", function() {

--- a/test/test.controlStructures.js
+++ b/test/test.controlStructures.js
@@ -1,4 +1,4 @@
-var Twig = Twig || require("../twig"),
+var Twig = Twig || requireUncached("../twig"),
     twig = twig || Twig.twig;
 
 describe("Twig.js Control Structures ->", function() {

--- a/test/test.core.js
+++ b/test/test.core.js
@@ -1,4 +1,4 @@
-var Twig = Twig || require("../twig"),
+var Twig = Twig || requireUncached("../twig"),
     twig = twig || Twig.twig;
 
 describe("Twig.js Core ->", function() {

--- a/test/test.embed.js
+++ b/test/test.embed.js
@@ -1,4 +1,4 @@
-var Twig = Twig || require("../twig"),
+var Twig = Twig || requireUncached("../twig"),
     twig = twig || Twig.twig;
 
 describe("Twig.js Embed ->", function() {

--- a/test/test.exports.js
+++ b/test/test.exports.js
@@ -1,4 +1,4 @@
-var Twig = Twig || require("../twig"),
+var Twig = Twig || requireUncached("../twig"),
     twig = twig || Twig.twig;
 
 describe("Twig.js Exports __express ->", function() {

--- a/test/test.expressions.js
+++ b/test/test.expressions.js
@@ -1,4 +1,4 @@
-var Twig = Twig || require("../twig"),
+var Twig = Twig || requireUncached("../twig"),
     twig = twig || Twig.twig;
 
 describe("Twig.js Expressions ->", function() {

--- a/test/test.expressions.operators.js
+++ b/test/test.expressions.operators.js
@@ -1,4 +1,4 @@
-var Twig = Twig || require("../twig"),
+var Twig = Twig || requireUncached("../twig"),
     twig = twig || Twig.twig;
 
 describe("Twig.js Expression Operators ->", function() {

--- a/test/test.extends.js
+++ b/test/test.extends.js
@@ -1,4 +1,4 @@
-var Twig = Twig || require("../twig"),
+var Twig = Twig || requireUncached("../twig"),
     twig = twig || Twig.twig;
 
 describe("Twig.js Extensions ->", function() {

--- a/test/test.filters.js
+++ b/test/test.filters.js
@@ -1,4 +1,4 @@
-var Twig = Twig || require("../twig"),
+var Twig = Twig || requireUncached("../twig"),
     twig = twig || Twig.twig;
 
 describe("Twig.js Filters ->", function() {

--- a/test/test.fs.js
+++ b/test/test.fs.js
@@ -1,4 +1,4 @@
-var Twig = Twig || require("../twig"),
+var Twig = Twig || requireUncached("../twig"),
     twig = twig || Twig.twig;
 
 describe("Twig.js Loader ->", function() {

--- a/test/test.functions.js
+++ b/test/test.functions.js
@@ -1,4 +1,4 @@
-var Twig = Twig || require("../twig"),
+var Twig = Twig || requireUncached("../twig"),
     twig = twig || Twig.twig;
 
 describe("Twig.js Functions ->", function() {

--- a/test/test.loaders.js
+++ b/test/test.loaders.js
@@ -1,4 +1,4 @@
-var Twig = Twig || require("../twig"),
+var Twig = Twig || requireUncached("../twig"),
     twig = twig || Twig.twig;
 
 describe("Twig.js Loaders ->", function() {

--- a/test/test.logic.js
+++ b/test/test.logic.js
@@ -1,4 +1,4 @@
-var Twig = Twig || require("../twig"),
+var Twig = Twig || requireUncached("../twig"),
     twig = twig || Twig.twig;
 
 describe("Twig.js Logic ->", function() {

--- a/test/test.macro.js
+++ b/test/test.macro.js
@@ -1,4 +1,4 @@
-var Twig = Twig || require("../twig"),
+var Twig = Twig || requireUncached("../twig"),
     twig = twig || Twig.twig;
 
 describe("Twig.js Macro ->", function() {
@@ -70,7 +70,7 @@ describe("Twig.js Macro ->", function() {
             async: false
         });
         // Load the template
-        twig({ref: 'from-macro-import'}).render({ }).trim().should.equal( 'Twig.js<div class="field"><input type="text" name="text" value="" size="20" /></div><div class="field red"><input type="text" name="password" value="" size="20" /></div>' );
+        twig({ref: 'from-macro-import'}).render({ }).trim().should.equal( 'Hello Twig.js<div class="field"><input type="text" name="text" value="" size="20" /></div><div class="field red"><input type="text" name="password" value="" size="20" /></div>' );
     });
 
     it("should support inline includes by ID", function() {
@@ -85,7 +85,7 @@ describe("Twig.js Macro ->", function() {
             }),
             output = template.render()
 
-        output.should.equal("template with Twig.js");
+        output.should.equal("template with Hello Twig.js");
     });
 
 });

--- a/test/test.namespaces.js
+++ b/test/test.namespaces.js
@@ -1,4 +1,4 @@
-var Twig = Twig || require("../twig"),
+var Twig = Twig || requireUncached("../twig"),
     twig = twig || Twig.twig;
 
 describe("Twig.js Namespaces ->", function() {

--- a/test/test.options.js
+++ b/test/test.options.js
@@ -1,4 +1,4 @@
-var Twig = Twig || require("../twig"),
+var Twig = Twig || requireUncached("../twig"),
     twig = twig || Twig.twig;
 
 describe("Twig.js Optional Functionality ->", function() {

--- a/test/test.parsers.js
+++ b/test/test.parsers.js
@@ -1,4 +1,4 @@
-var Twig = Twig || require("../twig"),
+var Twig = Twig || requireUncached("../twig"),
     twig = twig || Twig.twig;
 
 describe("Twig.js Parsers ->", function() {

--- a/test/test.path.js
+++ b/test/test.path.js
@@ -1,4 +1,4 @@
-var Twig = Twig || require("../twig"),
+var Twig = Twig || requireUncached("../twig"),
     twig = twig || Twig.twig;
 
 describe("Twig.js Path ->", function() {

--- a/test/test.regression.js
+++ b/test/test.regression.js
@@ -1,4 +1,4 @@
-var Twig = Twig || require("../twig"),
+var Twig = Twig || requireUncached("../twig"),
     twig = twig || Twig.twig;
 
 describe("Twig.js Regression Tests ->", function() {

--- a/test/test.rethrow.js
+++ b/test/test.rethrow.js
@@ -1,8 +1,4 @@
-var path = require('path');
-
-delete require.cache[path.resolve(path.join(__dirname, '../twig.js'))];
-
-var Twig = Twig || require("../twig"),
+var Twig = Twig || requireUncached("../twig"),
     twig = twig || Twig.twig;
 
 describe("Twig.js Rethrow ->", function() {

--- a/test/test.tags.js
+++ b/test/test.tags.js
@@ -1,4 +1,4 @@
-var Twig = Twig || require("../twig"),
+var Twig = Twig || requireUncached("../twig"),
     twig = twig || Twig.twig;
 
 describe("Twig.js Tags ->", function() {

--- a/test/test.tests.js
+++ b/test/test.tests.js
@@ -1,4 +1,4 @@
-var Twig = Twig || require("../twig"),
+var Twig = Twig || requireUncached("../twig"),
     twig = twig || Twig.twig;
 
 describe("Twig.js Tests ->", function() {


### PR DESCRIPTION
This commit fix the issue by using [require-uncached](https://www.npmjs.com/package/require-uncached) to require twig in the tests suite.

Two macro tests have also been fixed since they were returning false positive due to the twig instance being polluted by previous tests.