### PR TITLE
update embed regex in demos and docs

### DIFF
--- a/demos/node_express/public/vendor/twig.js
+++ b/demos/node_express/public/vendor/twig.js
@@ -3535,7 +3535,7 @@ var Twig = (function (Twig) {
              *  Format: {% embed "template.twig" [with {some: 'values'} only] %}
              */
             type: Twig.logic.type.embed,
-            regex: /^embed\s+(ignore missing\s+)?(.+?)\s*(?:with\s+(.+?))?\s*(only)?$/,
+            regex: /^embed\s+(.+?)(?:\s|$)(ignore missing(?:\s|$))?(?:with\s+([\S\s]+?))?(?:\s|$)(only)?$/,
             next: [
                 Twig.logic.type.endembed
             ],

--- a/demos/twitter_backbone/vendor/twig.js
+++ b/demos/twitter_backbone/vendor/twig.js
@@ -3535,7 +3535,7 @@ var Twig = (function (Twig) {
              *  Format: {% embed "template.twig" [with {some: 'values'} only] %}
              */
             type: Twig.logic.type.embed,
-            regex: /^embed\s+(ignore missing\s+)?(.+?)\s*(?:with\s+(.+?))?\s*(only)?$/,
+            regex: /^embed\s+(.+?)(?:\s|$)(ignore missing(?:\s|$))?(?:with\s+([\S\s]+?))?(?:\s|$)(only)?$/,
             next: [
                 Twig.logic.type.endembed
             ],

--- a/docs/twig.html
+++ b/docs/twig.html
@@ -6285,7 +6285,7 @@ Loops should be exempted as well.</p>
              *  Format: {% embed "template.twig" [with {some: 'values'} only] %}
              */</span>
             type: Twig.logic.type.embed,
-            regex: <span class="hljs-regexp">/^embed\s+(ignore missing\s+)?(.+?)\s*(?:with\s+(.+?))?\s*(only)?$/</span>,
+            regex: <span class="hljs-regexp">/^embed\s+(.+?)(?:\s|$)(ignore missing(?:\s|$))?(?:with\s+([\S\s]+?))?(?:\s|$)(only)?$/</span>,
             next: [
                 Twig.logic.type.endembed
             ],


### PR DESCRIPTION
Updates the embed regex in the docs and demo to match [twig.logic.js:1032](https://github.com/twigjs/twig.js/blob/master/src/twig.logic.js#L1032) (change introduced in dbf1fc7, which I think obviates #390)
