### PR TITLE
Rendering performance improvements

### DIFF
--- a/src/twig.async.js
+++ b/src/twig.async.js
@@ -206,6 +206,11 @@ module.exports = function (Twig) {
                 return;
             }
 
+            if (p._state == STATE_RESOLVED) {
+                results[index] = p._value;
+                return;
+            }
+
             return p.then(function promiseAllThen(v) {
                 results[index] = v;
             });

--- a/src/twig.core.js
+++ b/src/twig.core.js
@@ -541,7 +541,7 @@ module.exports = function (Twig) {
                 next = null;
 
             var compile_output = function(token) {
-                Twig.expression.compile.apply(self, [token]);
+                Twig.expression.compile.call(self, token);
                 if (stack.length > 0) {
                     intermediate_output.push(token);
                 } else {
@@ -551,7 +551,7 @@ module.exports = function (Twig) {
 
             var compile_logic = function(token) {
                 // Compile the logic token
-                logic_token = Twig.logic.compile.apply(self, [token]);
+                logic_token = Twig.logic.compile.call(self, token);
 
                 type = logic_token.type;
                 open = Twig.logic.handler[type].open;
@@ -804,7 +804,7 @@ module.exports = function (Twig) {
                 case Twig.token.type.logic:
                     var logic_token = token.token;
 
-                    return Twig.logic.parseAsync.apply(that, [logic_token, context, chain])
+                    return Twig.logic.parseAsync.call(that, logic_token, context, chain)
                     .then(function(logic) {
                         if (logic.chain !== undefined) {
                             chain = logic.chain;
@@ -829,14 +829,14 @@ module.exports = function (Twig) {
                 case Twig.token.type.output:
                     Twig.log.debug("Twig.parse: ", "Output token: ", token.stack);
                     // Parse the given expression in the given context
-                    return Twig.expression.parseAsync.apply(that, [token.stack, context])
+                    return Twig.expression.parseAsync.call(that, token.stack, context)
                     .then(function(o) {
                         output.push(o);
                     });
             }
         })
         .then(function() {
-            output = Twig.output.apply(that, [output]);
+            output = Twig.output.call(that, output);
             is_async = false;
             return output;
         })
@@ -876,11 +876,11 @@ module.exports = function (Twig) {
 
         // Tokenize
         Twig.log.debug("Twig.prepare: ", "Tokenizing ", data);
-        raw_tokens = Twig.tokenize.apply(this, [data]);
+        raw_tokens = Twig.tokenize.call(this, data);
 
         // Compile
         Twig.log.debug("Twig.prepare: ", "Compiling ", raw_tokens);
-        tokens = Twig.compile.apply(this, [raw_tokens]);
+        tokens = Twig.compile.call(this, raw_tokens);
 
         Twig.log.debug("Twig.prepare: ", "Compiled ", tokens);
 
@@ -1208,7 +1208,7 @@ module.exports = function (Twig) {
         this.reset(blocks);
 
         if (is('String', data)) {
-            this.tokens = Twig.prepare.apply(this, [data]);
+            this.tokens = Twig.prepare.call(this, data);
         } else {
             this.tokens = data;
         }
@@ -1297,7 +1297,7 @@ module.exports = function (Twig) {
             }
         };
 
-        promise = Twig.parseAsync.apply(this, [this.tokens, this.context])
+        promise = Twig.parseAsync.call(this, this.tokens, this.context)
         .then(cb)
         .then(function(v) {
             is_async = false;

--- a/src/twig.core.js
+++ b/src/twig.core.js
@@ -296,15 +296,16 @@ module.exports = function (Twig) {
     Twig.token.findStart = function (template) {
         var output = {
                 position: null,
-                close_position: null,
                 def: null
             },
+            close_position = null,
+            len = Twig.token.definitions.length,
             i,
             token_template,
             first_key_position,
             close_key_position;
 
-        for (i=0;i<Twig.token.definitions.length;i++) {
+        for (i=0;i<len;i++) {
             token_template = Twig.token.definitions[i];
             first_key_position = template.indexOf(token_template.open);
             close_key_position = template.indexOf(token_template.close);
@@ -326,7 +327,7 @@ module.exports = function (Twig) {
             if (first_key_position >= 0 && (output.position === null || first_key_position < output.position)) {
                 output.position = first_key_position;
                 output.def = token_template;
-                output.close_position = close_key_position;
+                close_position = close_key_position;
             } else if (first_key_position >= 0 && output.position !== null && first_key_position === output.position) {
                 /*This token exactly matches another token,
                 greedily match to check if this token has a greater specificity*/
@@ -334,30 +335,30 @@ module.exports = function (Twig) {
                     //This token's opening tag is more specific than the previous match
                     output.position = first_key_position;
                     output.def = token_template;
-                    output.close_position = close_key_position;
+                    close_position = close_key_position;
                 } else if (token_template.open.length === output.def.open.length) {
                     if (token_template.close.length > output.def.close.length) {
                         //This token's opening tag is as specific as the previous match,
                         //but the closing tag has greater specificity
-                        if (close_key_position >= 0 && close_key_position < output.close_position) {
+                        if (close_key_position >= 0 && close_key_position < close_position) {
                             //This token's closing tag exists in the template,
                             //and it occurs sooner than the previous match
                             output.position = first_key_position;
                             output.def = token_template;
-                            output.close_position = close_key_position;
+                            close_position = close_key_position;
                         }
-                    } else if (close_key_position >= 0 && close_key_position < output.close_position) {
+                    } else if (close_key_position >= 0 && close_key_position < close_position) {
                         //This token's closing tag is not more specific than the previous match,
                         //but it occurs sooner than the previous match
                         output.position = first_key_position;
                         output.def = token_template;
-                        output.close_position = close_key_position;
+                        close_position = close_key_position;
                     }
                 }
             }
         }
 
-        delete output['close_position'];
+        // delete output['close_position'];
 
         return output;
     };

--- a/src/twig.expression.js
+++ b/src/twig.expression.js
@@ -6,7 +6,7 @@ module.exports = function (Twig) {
 
     function parseParams(thisArg, params, context) {
         if (params)
-            return Twig.expression.parseAsync.apply(thisArg, [params, context]);
+            return Twig.expression.parseAsync.call(thisArg, params, context);
 
         return Twig.Promise.resolve(false);
     }
@@ -284,7 +284,7 @@ module.exports = function (Twig) {
                     stack.push(token);
                 } else if (token.params) {
                     // handle "{(expression):value}"
-                    return Twig.expression.parseAsync.apply(this, [token.params, context])
+                    return Twig.expression.parseAsync.call(this, token.params, context)
                     .then(function(key) {
                         token.key = key;
                         stack.push(token);
@@ -469,7 +469,7 @@ module.exports = function (Twig) {
                     value = null;
 
                 if (token.expression) {
-                    return Twig.expression.parseAsync.apply(this, [token.params, context])
+                    return Twig.expression.parseAsync.call(this, token.params, context)
                     .then(function(value) {
                         stack.push(value);
                     });
@@ -551,7 +551,7 @@ module.exports = function (Twig) {
                     value = null;
 
                 if (token.expression) {
-                    return Twig.expression.parseAsync.apply(this, [token.params, context])
+                    return Twig.expression.parseAsync.call(this, token.params, context)
                     .then(function(value) {
                         stack.push(value);
                     });
@@ -601,7 +601,7 @@ module.exports = function (Twig) {
                 var input = stack.pop(),
                     params = token.params;
 
-                stack.push(Twig.filter.apply(this, [token.value, input, params]));
+                stack.push(Twig.filter.call(this, token.value, input, params));
             }
         },
         {
@@ -757,7 +757,7 @@ module.exports = function (Twig) {
 
                 return parseParams(this, token.params, context)
                 .then(function(params) {
-                    return Twig.filter.apply(that, [token.value, input, params]);
+                    return Twig.filter.call(that, token.value, input, params);
                 })
                 .then(function(value) {
                     stack.push(value);
@@ -833,7 +833,7 @@ module.exports = function (Twig) {
             },
             parse: function(token, stack, context) {
                 // Get the variable from the context
-                return Twig.expression.resolveAsync.apply(this, [context[token.value], context])
+                return Twig.expression.resolveAsync.call(this, context[token.value], context)
                 .then(function(value) {
                     stack.push(value);
                 });
@@ -883,7 +883,7 @@ module.exports = function (Twig) {
                     }
 
                     // When resolving an expression we need to pass next_token in case the expression is a function
-                    return Twig.expression.resolveAsync.apply(that, [value, context, params, next_token, object]);
+                    return Twig.expression.resolveAsync.call(that, value, context, params, next_token, object);
                 })
                 .then(function(result) {
                     stack.push(result);
@@ -917,7 +917,7 @@ module.exports = function (Twig) {
                 return parseParams(this, token.params, context)
                 .then(function(parameters) {
                     params = parameters;
-                    return Twig.expression.parseAsync.apply(that, [token.stack, context]);
+                    return Twig.expression.parseAsync.call(that, token.stack, context);
                 })
                 .then(function(key) {
                     object = stack.pop();
@@ -938,7 +938,7 @@ module.exports = function (Twig) {
                     }
 
                     // When resolving an expression we need to pass next_token in case the expression is a function
-                    return Twig.expression.resolveAsync.apply(that, [value, object, params, next_token]);
+                    return Twig.expression.resolveAsync.call(that, value, object, params, next_token);
                 })
                 .then(function(result) {
                     stack.push(result);
@@ -1015,7 +1015,7 @@ module.exports = function (Twig) {
                 var tokens_are_parameters = true;
 
                 promise = promise.then(function() {
-                    return next_token.params && Twig.expression.parseAsync.apply(this, [next_token.params, context, tokens_are_parameters]);
+                    return next_token.params && Twig.expression.parseAsync.call(this, next_token.params, context, tokens_are_parameters);
                 })
                 .then(function(p) {
                     //Clean up the parentheses tokens on the next loop
@@ -1037,7 +1037,7 @@ module.exports = function (Twig) {
         var is_async = true,
             result;
 
-        Twig.expression.resolveAsync.apply(this, [value, context, params, next_token, object])
+        Twig.expression.resolveAsync.call(this, value, context, params, next_token, object)
         .then(function(r) {
             is_async = false;
             result = r;
@@ -1290,7 +1290,7 @@ module.exports = function (Twig) {
             token_template = Twig.expression.handler[token.type];
 
             if (token_template.parse)
-                result = token_template.parse.apply(that, [token, stack, context, next_token]);
+                result = token_template.parse.call(that, token, stack, context, next_token);
 
             //Store any binary tokens for later if we are in a loop.
             if (context.loop && token.type === Twig.expression.type.operator.binary) {

--- a/src/twig.filters.js
+++ b/src/twig.filters.js
@@ -722,7 +722,7 @@ module.exports = function (Twig) {
         if (!Twig.filters[filter]) {
             throw "Unable to find filter " + filter;
         }
-        return Twig.filters[filter].apply(this, [value, params]);
+        return Twig.filters[filter].call(this, value, params);
     };
 
     Twig.filter.extend = function(filter, definition) {

--- a/src/twig.functions.js
+++ b/src/twig.functions.js
@@ -158,7 +158,7 @@ module.exports = function (Twig) {
         },
         block: function(block) {
             if (this.originalBlockTokens[block]) {
-                return Twig.logic.parse.apply(this, [this.originalBlockTokens[block], this.context]).output;
+                return Twig.logic.parse.call(this, this.originalBlockTokens[block], this.context).output;
             } else {
                 return this.blocks[block];
             }
@@ -211,9 +211,8 @@ module.exports = function (Twig) {
 
             function getRandomNumber(n) {
                 var random = Math.floor(Math.random() * LIMIT_INT31);
-                var limits = [0, n];
-                var min = Math.min.apply(null, limits),
-                    max = Math.max.apply(null, limits);
+                var min = Math.min.call(null, 0, n),
+                    max = Math.max.call(null, 0, n);
                 return min + Math.floor((max - min + 1) * random / LIMIT_INT31);
             }
 

--- a/src/twig.functions.js
+++ b/src/twig.functions.js
@@ -67,11 +67,14 @@ module.exports = function (Twig) {
             return arr[pos];
         },
         dump: function() {
+            // Don't pass arguments to `Array.slice`, that is a performance killer
+            var args_i = arguments.length; args = new Array(args_i);
+            while(args_i-- > 0) args[args_i] = arguments[args_i];
+
             var EOL = '\n',
                 indentChar = '  ',
                 indentTimes = 0,
                 out = '',
-                args = Array.prototype.slice.call(arguments),
                 indent = function(times) {
                     var ind  = '';
                     while (times > 0) {

--- a/src/twig.lib.js
+++ b/src/twig.lib.js
@@ -21,10 +21,21 @@ module.exports = function(Twig) {
     Twig.lib.date = require('locutus/php/datetime/date');
     Twig.lib.boolval = require('locutus/php/var/boolval');
 
+    var toString = Object.prototype.toString;
+
     Twig.lib.is = function(type, obj) {
-        var clas = Object.prototype.toString.call(obj).slice(8, -1);
-        return obj !== undefined && obj !== null && clas === type;
+        if (typeof obj === 'undefined' || obj === null)
+            return false;
+
+        if (type === 'Array' && Array.isArray)
+            return Array.isArray(obj);
+
+        return toString.call(obj).slice(8, -1) === type;
     };
+
+    Twig.lib.isArray = Array.isArray || function(obj) {
+        return toString.call(obj).slice(8, -1) === 'Array';
+    }
 
     // shallow-copy an object
     Twig.lib.copy = function(src) {

--- a/src/twig.logic.js
+++ b/src/twig.logic.js
@@ -606,7 +606,9 @@ module.exports = function (Twig) {
                 return token;
             },
             parse: function (token, context, chain) {
-                return Twig.logic.handler[Twig.logic.type.block].parse.apply(this, arguments);
+                var args = new Array(arguments.length), args_i = arguments.length;
+                while(args_i-- > 0) args[args_i] = arguments[args_i];
+                return Twig.logic.handler[Twig.logic.type.block].parse.apply(this, args);
             }
         },
         {

--- a/src/twig.logic.js
+++ b/src/twig.logic.js
@@ -80,24 +80,24 @@ module.exports = function (Twig) {
             compile: function (token) {
                 var expression = token.match[1];
                 // Compile the expression.
-                token.stack = Twig.expression.compile.apply(this, [{
+                token.stack = Twig.expression.compile.call(this, {
                     type:  Twig.expression.type.expression,
                     value: expression
-                }]).stack;
+                }).stack;
                 delete token.match;
                 return token;
             },
             parse: function (token, context, chain) {
                 var that = this;
 
-                return Twig.expression.parseAsync.apply(this, [token.stack, context])
+                return Twig.expression.parseAsync.call(this, token.stack, context)
                 .then(function(result) {
                     chain = true;
 
                     if (Twig.lib.boolval(result)) {
                         chain = false;
 
-                        return Twig.parseAsync.apply(that, [token.output, context]);
+                        return Twig.parseAsync.call(that, token.output, context);
                     }
 
                     return '';
@@ -127,22 +127,22 @@ module.exports = function (Twig) {
             compile: function (token) {
                 var expression = token.match[1];
                 // Compile the expression.
-                token.stack = Twig.expression.compile.apply(this, [{
+                token.stack = Twig.expression.compile.call(this, {
                     type:  Twig.expression.type.expression,
                     value: expression
-                }]).stack;
+                }).stack;
                 delete token.match;
                 return token;
             },
             parse: function (token, context, chain) {
                 var that = this;
 
-                return Twig.expression.parseAsync.apply(this, [token.stack, context])
+                return Twig.expression.parseAsync.call(this, token.stack, context)
                 .then(function(result) {
                     if (chain && Twig.lib.boolval(result)) {
                         chain = false;
 
-                        return Twig.parseAsync.apply(that, [token.output, context]);
+                        return Twig.parseAsync.call(that, token.output, context);
                     }
 
                     return '';
@@ -172,7 +172,7 @@ module.exports = function (Twig) {
                 var promise = Twig.Promise.resolve('');
 
                 if (chain) {
-                    promise = Twig.parseAsync.apply(this, [token.output, context]);
+                    promise = Twig.parseAsync.call(this, token.output, context);
                 }
 
                 return promise.then(function(output) {
@@ -233,17 +233,17 @@ module.exports = function (Twig) {
                 //   for key,item in expression
 
                 // Compile the expression.
-                token.expression = Twig.expression.compile.apply(this, [{
+                token.expression = Twig.expression.compile.call(this, {
                     type:  Twig.expression.type.expression,
                     value: expression
-                }]).stack;
+                }).stack;
 
                 // Compile the conditional (if available)
                 if (conditional) {
-                    token.conditional = Twig.expression.compile.apply(this, [{
+                    token.conditional = Twig.expression.compile.call(this, {
                         type:  Twig.expression.type.expression,
                         value: conditional
-                    }]).stack;
+                    }).stack;
                 }
 
                 delete token.match;
@@ -285,13 +285,13 @@ module.exports = function (Twig) {
 
                         var promise = conditional === undefined ?
                             Twig.Promise.resolve(true) :
-                            Twig.expression.parseAsync.apply(that, [conditional, inner_context]);
+                            Twig.expression.parseAsync.call(that, conditional, inner_context);
 
                         promise.then(function(condition) {
                             if (!condition)
                                 return;
 
-                            return Twig.parseAsync.apply(that, [token.output, inner_context])
+                            return Twig.parseAsync.call(that, token.output, inner_context)
                             .then(function(o) {
                                 output.push(o);
                                 index += 1;
@@ -310,7 +310,7 @@ module.exports = function (Twig) {
                     };
 
 
-                return Twig.expression.parseAsync.apply(this, [token.expression, context])
+                return Twig.expression.parseAsync.call(this, token.expression, context)
                 .then(function(result) {
                     if (Twig.lib.isArray(result)) {
                         len = result.length;
@@ -339,7 +339,7 @@ module.exports = function (Twig) {
 
                     return {
                         chain: continue_chain,
-                        output: Twig.output.apply(that, [output])
+                        output: Twig.output.call(that, output)
                     };
                 });
             }
@@ -369,10 +369,10 @@ module.exports = function (Twig) {
                 var key = token.match[1].trim(),
                     expression = token.match[2],
                     // Compile the expression.
-                    expression_stack  = Twig.expression.compile.apply(this, [{
+                    expression_stack  = Twig.expression.compile.call(this, {
                         type:  Twig.expression.type.expression,
                         value: expression
-                    }]).stack;
+                    }).stack;
 
                 token.key = key;
                 token.expression = expression_stack;
@@ -383,7 +383,7 @@ module.exports = function (Twig) {
             parse: function (token, context, continue_chain) {
                 var key = token.key;
 
-                return Twig.expression.parseAsync.apply(this, [token.expression, context])
+                return Twig.expression.parseAsync.call(this, token.expression, context)
                 .then(function(value) {
                     if (value === context) {
                         /*  If storing the context in a variable, it needs to be a clone of the current state of context.
@@ -426,7 +426,7 @@ module.exports = function (Twig) {
                 var that = this,
                     key = token.key;
 
-                return Twig.parseAsync.apply(this, [token.output, context])
+                return Twig.parseAsync.call(this, token.output, context)
                 .then(function(value) {
                     // set on both the global and local context
                     that.context[key] = value;
@@ -465,22 +465,22 @@ module.exports = function (Twig) {
             compile: function (token) {
                 var expression = "|" + token.match[1].trim();
                 // Compile the expression.
-                token.stack = Twig.expression.compile.apply(this, [{
+                token.stack = Twig.expression.compile.call(this, {
                     type:  Twig.expression.type.expression,
                     value: expression
-                }]).stack;
+                }).stack;
                 delete token.match;
                 return token;
             },
             parse: function (token, context, chain) {
-                return Twig.parseAsync.apply(this, [token.output, context])
+                return Twig.parseAsync.call(this, token.output, context)
                 .then(function(unfiltered) {
                     var stack = [{
                         type: Twig.expression.type.string,
                         value: unfiltered
                     }].concat(token.stack);
 
-                    return Twig.expression.parseAsync.apply(that, [stack, context]);
+                    return Twig.expression.parseAsync.call(that, stack, context);
                 })
                 .then(function(output) {
                     return {
@@ -530,20 +530,20 @@ module.exports = function (Twig) {
                 // Loops should be exempted as well.
                 if (this.blocks[token.block] === undefined || isImported || hasParent || context.loop || token.overwrite) {
                     if (token.expression) {
-                        promise = Twig.expression.parseAsync.apply(this, [token.output, context])
+                        promise = Twig.expression.parseAsync.call(this, token.output, context)
                         .then(function(value) {
-                            return Twig.expression.parseAsync.apply(that, [{
+                            return Twig.expression.parseAsync.call(that, {
                                 type: Twig.expression.type.string,
                                 value: value
-                            }, context]);
+                            }, context);
                         });
                     } else {
-                        promise = Twig.parseAsync.apply(this, [token.output, context])
+                        promise = Twig.parseAsync.call(this, token.output, context)
                         .then(function(value) {
-                            return Twig.expression.parseAsync.apply(that, [{
+                            return Twig.expression.parseAsync.call(that, {
                                 type: Twig.expression.type.string,
                                 value: value
-                            }, context]);
+                            }, context);
                         });
                     }
 
@@ -636,10 +636,10 @@ module.exports = function (Twig) {
                 var expression = token.match[1].trim();
                 delete token.match;
 
-                token.stack   = Twig.expression.compile.apply(this, [{
+                token.stack   = Twig.expression.compile.call(this, {
                     type:  Twig.expression.type.expression,
                     value: expression
-                }]).stack;
+                }).stack;
 
                 return token;
             },
@@ -649,7 +649,7 @@ module.exports = function (Twig) {
                     innerContext = Twig.ChildContext(context);
 
                 // Resolve filename
-                return Twig.expression.parseAsync.apply(this, [token.stack, context])
+                return Twig.expression.parseAsync.call(this, token.stack, context)
                 .then(function(file) {
                     // Set parent template
                     that.extend = file;
@@ -689,10 +689,10 @@ module.exports = function (Twig) {
                 var expression = token.match[1].trim();
                 delete token.match;
 
-                token.stack = Twig.expression.compile.apply(this, [{
+                token.stack = Twig.expression.compile.call(this, {
                     type:  Twig.expression.type.expression,
                     value: expression
-                }]).stack;
+                }).stack;
 
                 return token;
             },
@@ -700,7 +700,7 @@ module.exports = function (Twig) {
                 var that = this;
 
                 // Resolve filename
-                return Twig.expression.parseAsync.apply(this, [token.stack, context])
+                return Twig.expression.parseAsync.call(this, token.stack, context)
                 .then(function(file) {
                     // Import blocks
                     that.importBlocks(file);
@@ -734,16 +734,16 @@ module.exports = function (Twig) {
                 token.only = only;
                 token.ignoreMissing = ignoreMissing;
 
-                token.stack = Twig.expression.compile.apply(this, [{
+                token.stack = Twig.expression.compile.call(this, {
                     type:  Twig.expression.type.expression,
                     value: expression
-                }]).stack;
+                }).stack;
 
                 if (withContext !== undefined) {
-                    token.withStack = Twig.expression.compile.apply(this, [{
+                    token.withStack = Twig.expression.compile.call(this, {
                         type:  Twig.expression.type.expression,
                         value: withContext.trim()
-                    }]).stack;
+                    }).stack;
                 }
 
                 return token;
@@ -761,7 +761,7 @@ module.exports = function (Twig) {
                 }
 
                 if (token.withStack !== undefined) {
-                    promise = Twig.expression.parseAsync.apply(this, [token.withStack, context])
+                    promise = Twig.expression.parseAsync.call(this, token.withStack, context)
                     .then(function(withContext) {
                         for (i in withContext) {
                             if (withContext.hasOwnProperty(i))
@@ -772,7 +772,7 @@ module.exports = function (Twig) {
 
                 return promise
                 .then(function() {
-                    return Twig.expression.parseAsync.apply(that, [token.stack, context]);
+                    return Twig.expression.parseAsync.call(that, token.stack, context);
                 })
                 .then(function(file) {
                     if (file instanceof Twig.Template) {
@@ -811,7 +811,7 @@ module.exports = function (Twig) {
             // Parse the html and return it without any spaces between tags
             parse: function (token, context, chain) {
                 // Parse the output without any filter
-                return Twig.parseAsync.apply(this, [token.output, context])
+                return Twig.parseAsync.call(this, token.output, context)
                 .then(function(unfiltered) {
                     var // A regular expression to find closing and opening tags with spaces between them
                         rBetweenTagSpaces = />\s+</g,
@@ -884,7 +884,7 @@ module.exports = function (Twig) {
                     }
 
                     // Render
-                    return Twig.parseAsync.apply(template, [token.output, macroContext]);
+                    return Twig.parseAsync.call(template, token.output, macroContext);
                 };
 
                 return {
@@ -923,10 +923,10 @@ module.exports = function (Twig) {
                 token.expression = expression;
                 token.contextName = contextName;
 
-                token.stack = Twig.expression.compile.apply(this, [{
+                token.stack = Twig.expression.compile.call(this, {
                     type: Twig.expression.type.expression,
                     value: expression
-                }]).stack;
+                }).stack;
 
                 return token;
             },
@@ -939,7 +939,7 @@ module.exports = function (Twig) {
                     return Twig.Promise.resolve(output);
                 }
 
-                return Twig.expression.parseAsync.apply(this, [token.stack, context])
+                return Twig.expression.parseAsync.call(this, token.stack, context)
                 .then(function(file) {
                     return that.importFile(file || token.expression);
                 })
@@ -987,10 +987,10 @@ module.exports = function (Twig) {
                 token.expression = expression;
                 token.macroNames = macroNames;
 
-                token.stack = Twig.expression.compile.apply(this, [{
+                token.stack = Twig.expression.compile.call(this, {
                     type: Twig.expression.type.expression,
                     value: expression
-                }]).stack;
+                }).stack;
 
                 return token;
             },
@@ -999,7 +999,7 @@ module.exports = function (Twig) {
                     promise = Twig.Promise.resolve(this.macros);
 
                 if (token.expression !== "_self") {
-                    promise = Twig.expression.parseAsync.apply(this, [token.stack, context])
+                    promise = Twig.expression.parseAsync.call(this, token.stack, context)
                     .then(function(file) {
                         return that.importFile(file || token.expression);
                     })
@@ -1048,16 +1048,16 @@ module.exports = function (Twig) {
                 token.only = only;
                 token.ignoreMissing = ignoreMissing;
 
-                token.stack = Twig.expression.compile.apply(this, [{
+                token.stack = Twig.expression.compile.call(this, {
                     type:  Twig.expression.type.expression,
                     value: expression
-                }]).stack;
+                }).stack;
 
                 if (withContext !== undefined) {
-                    token.withStack = Twig.expression.compile.apply(this, [{
+                    token.withStack = Twig.expression.compile.call(this, {
                         type:  Twig.expression.type.expression,
                         value: withContext.trim()
-                    }]).stack;
+                    }).stack;
                 }
 
                 return token;
@@ -1078,7 +1078,7 @@ module.exports = function (Twig) {
                 }
 
                 if (token.withStack !== undefined) {
-                    promise = Twig.expression.parseAsync.apply(this, [token.withStack, context])
+                    promise = Twig.expression.parseAsync.call(this, token.withStack, context)
                     .then(function(withContext) {
                         for (i in withContext) {
                             if (withContext.hasOwnProperty(i))
@@ -1088,7 +1088,7 @@ module.exports = function (Twig) {
                 }
 
                 return promise.then(function() {
-                    return Twig.expression.parseAsync.apply(that, [token.stack, innerContext]);
+                    return Twig.expression.parseAsync.call(that, token.stack, innerContext);
                 })
                 .then(function(file) {
                     if (file instanceof Twig.Template) {
@@ -1110,7 +1110,7 @@ module.exports = function (Twig) {
                     that.blocks = {};
 
                     // parse tokens. output will be not used
-                    return Twig.parseAsync.apply(that, [token.output, innerContext])
+                    return Twig.parseAsync.call(that, token.output, innerContext)
                     .then(function() {
                         // render tempalte with blocks defined in embed block
                         return template.renderAsync(innerContext, {'blocks':that.blocks});
@@ -1193,12 +1193,12 @@ module.exports = function (Twig) {
      */
     Twig.logic.compile = function (raw_token) {
         var expression = raw_token.value.trim(),
-            token = Twig.logic.tokenize.apply(this, [expression]),
+            token = Twig.logic.tokenize.call(this, expression),
             token_template = Twig.logic.handler[token.type];
 
         // Check if the token needs compiling
         if (token_template.compile) {
-            token = token_template.compile.apply(this, [token]);
+            token = token_template.compile.call(this, token);
             Twig.log.trace("Twig.logic.compile: ", "Compiled logic token to ", token);
         }
 
@@ -1288,7 +1288,7 @@ module.exports = function (Twig) {
         token_template = Twig.logic.handler[token.type];
 
         if (token_template.parse) {
-            output = token_template.parse.apply(this, [token, context, chain]);
+            output = token_template.parse.call(this, token, context, chain);
         }
 
         promise = Twig.Promise.resolve(output);

--- a/test/test.performance.js
+++ b/test/test.performance.js
@@ -1,0 +1,41 @@
+var Twig = Twig || requireUncached("../twig"),
+    twig = twig || Twig.twig;
+
+describe("Twig.js Performance Regressions ->", function() {
+
+    var template = "{{ echo_test }}\
+    {% for item in items %}\
+        <h1>{{ item.title }}</h1>\
+        {% if item.is_active %}\
+            <h3 style=\"color: green;\">Active</h3>\
+        {% else %}\
+            <h3 style=\"color: red;\">Inactive</h3>\
+        {% endif %}\
+    {% endfor %}";
+
+    it("Should not start running slower", function() {
+        this.timeout(500);
+        this.retries(3);
+        this.slow(300);
+
+        console.time('Should not start running slower ');
+        for(var i = 0; i < 1000; i++) {
+            Twig.twig({
+                data: template
+            }).render({
+                echo_test: 'Data for echo',
+                items: [
+                    {
+                        title: "This is a title",
+                        is_active: true
+                    },
+                    {
+                        title: "This is a title",
+                        is_active: false
+                    }
+                ]
+            });
+        }
+    });
+
+});


### PR DESCRIPTION
As a result of https://github.com/twigjs/twig.js/issues/472 I've been looking into improving rendering performance. These changes reduce rendering times back to pre-async performance numbers.

**Updates**

- [Promise] Reduced the amount of closures used by a promise.
- [Promise] Reduced branching by replacing functions based on promise state.
- [Promise] Use numeric constants to check promise state.
- [Promise] Lazily convert `handlers` to an array.
- [Promise] Use `Twig.attempt` instead of `try/catch` ([optimization-killer](https://github.com/petkaantonov/bluebird/wiki/Optimization-killers#2-unsupported-syntax))
- [Promise] Move `append` out of constructor, js engine only has to optimize it once.
- [async/forEach] Reduce amount of closures.
- [async/forEach] Create less objects in memory.
- [Twig.compile] Use `Twig.attempt` instead of `try/catch`
- [Twig.expression.tokenize]: Don't leak `arguments` ([optimization-killer](https://github.com/petkaantonov/bluebird/wiki/Optimization-killers#32-leaking-arguments))

**Average rendering durations on different branches over 100 runs:**

These numbers are using some of our own internal templates, feel free to check this branch against your own.

- Current master: 0.422ms
- v0.10.3 ( pre-async ): 0.356ms
- This PR: 0.321ms

**Example of test script**

```js
#!/usr/bin/env node

const Twig = require('../twig');

let i = 100;
const duration = [];

while( i-- ) {
    console.time('twig');

    Twig.twig({
        data: 'Hello {{world}}'
    }).render({ world: 'World' });

    console.timeEnd('twig');
}
```