### PR TITLE
Bug: trim filter autoescapes

### DIFF
--- a/src/twig.filters.js
+++ b/src/twig.filters.js
@@ -480,7 +480,7 @@ module.exports = function (Twig) {
                 return;
             }
 
-            var str = Twig.filters.escape( '' + value ),
+            var str = '' + value,
                 whitespace;
             if ( params && params[0] ) {
                 whitespace = '' + params[0];

--- a/test/test.filters.js
+++ b/test/test.filters.js
@@ -504,6 +504,11 @@ describe("Twig.js Filters ->", function() {
             var test_template = twig({data: '{{ undef|trim }}' });
             test_template.render().should.equal("" );
         });
+
+        it("should not autoescape", function() {
+          var template = twig({data: '{{ test|trim }}'});
+          template.render({ test: '\r\n <a href="">Test</a>\n  ' }).should.equal("<a href=\"\">Test</a>");
+        });
     });
 
 


### PR DESCRIPTION
**Actual Behaviour:**

If autoescape = 'html' the following code:

```
{{ text | trim }}
```

with

```
test = '\r\n <a href="">Test</a>\n  '
```

will auto escape internally to:

```
&lt;a href=&quot;&quot;&gt;Test&lt;/a&gt;
```

so, it will escape just again afterwards to:

```
&amp;lt;a href=&amp;quot;&amp;quot;&amp;gt;Test&amp;lt;/a&amp;gt;
```

when it's printed.

A workaround is:

```
{{ text | trim | raw }}
```

**Expected behaviour:**

Escape only once.

**Steps taken**

0. Checked if twig php does the same thing https://github.com/twigphp/Twig/blob/fd98722d15996561f598f9181dbcef8432e9ff85/lib/Twig/Extension/Core.php#L158 ✅ 
1. Added failing test at https://travis-ci.org/twigjs/twig.js/builds/245690804 ✅ 
2. Fixed the test at https://travis-ci.org/twigjs/twig.js/builds/245691692 ✅ 
3. Created PR. ✅ 