### PR TITLE
fixes #250 Node_express demo throwing errors

### DIFF
--- a/demos/node_express/app.js
+++ b/demos/node_express/app.js
@@ -58,7 +58,6 @@ var notes = {
     }
 };
 
-
 app.configure(function () {
     app.use(express.static(__dirname + '/public'));
 		app.use(express.bodyParser());

--- a/demos/node_express/app.js
+++ b/demos/node_express/app.js
@@ -58,11 +58,13 @@ var notes = {
     }
 };
 
+
 app.configure(function () {
     app.use(express.static(__dirname + '/public'));
 		app.use(express.bodyParser());
     app.set('views', __dirname + '/public/views');
     app.set('view engine', 'twig');
+    app.set('twig options', {});
     // We don't need express to use a parent "page" layout
     // Twig.js has support for this using the {% extends parent %} tag
     app.set("view options", { layout: false });
@@ -140,4 +142,3 @@ var port = process.env.PORT || 9999,
 app.listen(port, host);
 
 console.log("Express Twig.js Demo is running on " + host + ":" + port);
-

--- a/src/twig.core.js
+++ b/src/twig.core.js
@@ -1127,7 +1127,7 @@ module.exports = function (Twig) {
 
         // Default to the URL so the template is cached.
         if (params.id === undefined) {
-            params.id = location;
+            params.id = Array.isArray(location) ? location[0] : location;
         }
 
         // Check for existing template

--- a/src/twig.exports.js
+++ b/src/twig.exports.js
@@ -37,6 +37,9 @@ module.exports = function (Twig) {
         if (params.trace !== undefined) {
             Twig.trace = params.trace;
         }
+        if (params.path && !Array.isArray(params.path)) {
+            params.path = [params.path]
+        }
 
         if (params.data !== undefined) {
             return Twig.Templates.parsers.twig({
@@ -52,7 +55,7 @@ module.exports = function (Twig) {
                 throw new Twig.Error("Both ref and id cannot be set on a twig.js template.");
             }
             return Twig.Templates.load(params.ref);
-        
+
         } else if (params.method !== undefined) {
             if (!Twig.Templates.isRegisteredLoader(params.method)) {
                 throw new Twig.Error('Loader for "' + params.method + '" is not defined.');

--- a/src/twig.path.js
+++ b/src/twig.path.js
@@ -20,24 +20,35 @@ module.exports = function (Twig) {
      */
      Twig.path.parsePath = function(template, file) {
         var namespaces = null,
-            file = file || "";
+            file = file || "",
+            files = [];
 
         if (typeof template === 'object' && typeof template.options === 'object') {
             namespaces = template.options.namespaces;
         }
 
-        if (typeof namespaces === 'object' && (file.indexOf('::') > 0) || file.indexOf('@') >= 0){
-            for (var k in namespaces){
-                if (namespaces.hasOwnProperty(k)) {
-                    file = file.replace(k + '::', namespaces[k]);
-                    file = file.replace('@' + k, namespaces[k]);
-                }
-            }
-
-            return file;
+        if (!Array.isArray(file)) {
+            files = [file];
+        } else {
+            files = file;
         }
 
-        return Twig.path.relativePath(template, file);
+        return files.reduce(function(acc, _file){
+            if (typeof namespaces === 'object' && (_file.indexOf('::') > 0) || _file.indexOf('@') >= 0){
+                for (var k in namespaces){
+                    if (namespaces.hasOwnProperty(k)) {
+                        _file = _file.replace(k + '::', namespaces[k]);
+                        _file = _file.replace('@' + k, namespaces[k]);
+                    }
+                }
+
+                acc.push(_file);
+            } else {
+                acc = acc.concat(Twig.path.relativePath(template, _file));
+            }
+
+            return acc;
+        }, []);
     };
 
     /**
@@ -51,6 +62,7 @@ module.exports = function (Twig) {
     Twig.path.relativePath = function(template, file) {
         var base,
             base_path,
+            bases = [],
             sep_chr = "/",
             new_path = [],
             file = file || "",
@@ -62,47 +74,63 @@ module.exports = function (Twig) {
             } else {
                 base = template.url;
             }
+            bases.push(base);
         } else if (template.path) {
             // Get the system-specific path separator
             var path = require("path"),
                 sep = path.sep || sep_chr,
-                relative = new RegExp("^\\.{1,2}" + sep.replace("\\", "\\\\"));
+                relative = new RegExp("^\\.{1,2}" + sep.replace("\\", "\\\\")),
+                pathNormalize = function(_path){
+
+                    if (template.base !== undefined && file.match(relative) == null) {
+                        file = file.replace(template.base, '');
+                        base = template.base + sep;
+                    } else {
+                        base = path.normalize(_path);
+                    }
+
+                    return base.replace(sep+sep, sep);
+                };
+
             file = file.replace(/\//g, sep);
 
-            if (template.base !== undefined && file.match(relative) == null) {
-                file = file.replace(template.base, '');
-                base = template.base + sep;
+            if (Array.isArray(template.path)) {
+                bases = template.path.map(pathNormalize);
             } else {
-                base = path.normalize(template.path);
+                bases.push(pathNormalize(template.path));
             }
 
-            base = base.replace(sep+sep, sep);
             sep_chr = sep;
         } else if ((template.name || template.id) && template.method && template.method !== 'fs' && template.method !== 'ajax') {
             // Custom registered loader
             base = template.base || template.name || template.id;
+            bases.push(base);
         } else {
             throw new Twig.Error("Cannot extend an inline template.");
         }
 
-        base_path = base.split(sep_chr);
 
-        // Remove file from url
-        base_path.pop();
-        base_path = base_path.concat(file.split(sep_chr));
+        return bases.map(function(base){
+            base_path = base.split(sep_chr);
 
-        while (base_path.length > 0) {
-            val = base_path.shift();
-            if (val == ".") {
-                // Ignore
-            } else if (val == ".." && new_path.length > 0 && new_path[new_path.length-1] != "..") {
-                new_path.pop();
-            } else {
-                new_path.push(val);
+            // Remove file from url
+            base_path.pop();
+            base_path = base_path.concat(file.split(sep_chr));
+
+            while (base_path.length > 0) {
+                val = base_path.shift();
+                if (val == ".") {
+                    // Ignore
+                } else if (val == ".." && new_path.length > 0 && new_path[new_path.length-1] != "..") {
+                    new_path.pop();
+                } else {
+                    new_path.push(val);
+                }
             }
-        }
 
-        return new_path.join(sep_chr);
+            var res = new_path.join(sep_chr);
+            return res;
+        })
     };
 
     return Twig;

--- a/test/test.loaders.js
+++ b/test/test.loaders.js
@@ -35,13 +35,13 @@ describe("Twig.js Loaders ->", function() {
         });
         it("should load a template that includes another from a custom loader", function() {
             twig({
-                method: 'custom', 
+                method: 'custom',
                 name: 'custom_loader_include'
             }).render({value: 'test succeeded'}).should.equal('include others from the same loader method - the value is: test succeeded');
         });
         it("should load a template that extends another from a custom loader", function() {
             twig({
-                method: 'custom', 
+                method: 'custom',
                 name: 'custom_loader_complex'
             }).render({value: 'test succeeded'}).should.equal('This lets you extend other templates and include others from the same loader method - the value is: test succeeded');
         });

--- a/test/test.path.js
+++ b/test/test.path.js
@@ -25,37 +25,37 @@ describe("Twig.js Path ->", function() {
         });
 
         it("should give the full path to a file when file is passed", function() {
-            relativePath({ url: "http://www.test.com/test.twig"}, "templates/myFile.twig").should.equal("http://www.test.com/templates/myFile.twig");
-            relativePath({ path: "test/test.twig"}, "templates/myFile.twig").should.equal("test/templates/myFile.twig");
+            relativePath({ url: "http://www.test.com/test.twig"}, "templates/myFile.twig")[0].should.equal("http://www.test.com/templates/myFile.twig");
+            relativePath({ path: "test/test.twig"}, "templates/myFile.twig")[0].should.equal("test/templates/myFile.twig");
         });
 
         it("should ascend directories", function() {
-            relativePath({ url: "http://www.test.com/templates/../test.twig"}, "myFile.twig").should.equal("http://www.test.com/myFile.twig");
-            relativePath({ path: "test/templates/../test.twig"}, "myFile.twig").should.equal("test/myFile.twig");
+            relativePath({ url: "http://www.test.com/templates/../test.twig"}, "myFile.twig")[0].should.equal("http://www.test.com/myFile.twig");
+            relativePath({ path: "test/templates/../test.twig"}, "myFile.twig")[0].should.equal("test/myFile.twig");
         });
 
         it("should respect relative directories", function() {
-            relativePath({ url: "http://www.test.com/templates/./test.twig"}, "myFile.twig").should.equal("http://www.test.com/templates/myFile.twig");
-            relativePath({ path: "test/templates/./test.twig"}, "myFile.twig").should.equal("test/templates/myFile.twig");
+            relativePath({ url: "http://www.test.com/templates/./test.twig"}, "myFile.twig")[0].should.equal("http://www.test.com/templates/myFile.twig");
+            relativePath({ path: "test/templates/./test.twig"}, "myFile.twig")[0].should.equal("test/templates/myFile.twig");
         });
 
         describe("url ->", function() {
             it("should use the url if no base is specified", function() {
-                relativePath({ url: "http://www.test.com/test.twig"}).should.equal("http://www.test.com/");
+                relativePath({ url: "http://www.test.com/test.twig"})[0].should.equal("http://www.test.com/");
             });
 
             it("should use the base if base is specified", function() {
-                relativePath({ url: "http://www.test.com/test.twig", base: "myTest" }).should.equal("myTest/");
+                relativePath({ url: "http://www.test.com/test.twig", base: "myTest" })[0].should.equal("myTest/");
             });
         });
 
         describe("path ->", function() {
             it("should use the path if no base is specified", function() {
-                relativePath({ path: "test/test.twig"}).should.equal("test/");
+                relativePath({ path: "test/test.twig"})[0].should.equal("test/");
             });
 
             it("should use the base if base is specified", function() {
-                relativePath({ path: "test/test.twig", base: "myTest" }).should.equal("myTest/");
+                relativePath({ path: "test/test.twig", base: "myTest" })[0].should.equal("myTest/");
             });
         });
     });

--- a/test/test.rethrow.js
+++ b/test/test.rethrow.js
@@ -71,4 +71,3 @@ describe("Twig.js Rethrow ->", function() {
         }
     });
 });
-


### PR DESCRIPTION
A tiny fix that allows the node_express demo to work again. Without the 'twig options' defined twig would throw an exception.

I couldn't find any tests for the demo so I've not included any.