### PR TITLE
Fixed an exception caused by a missing "that" reference

### DIFF
--- a/src/twig.logic.js
+++ b/src/twig.logic.js
@@ -475,6 +475,8 @@ module.exports = function (Twig) {
                 return token;
             },
             parse: function (token, context, chain) {
+                var that = this;
+
                 return Twig.parseAsync.call(this, token.output, context)
                 .then(function(unfiltered) {
                     var stack = [{


### PR DESCRIPTION
Looks like there is a missing "that" variable inside a "filter" token processing function that is causing a render exception.