### PR TITLE
Fixes failing with only test

### DIFF
--- a/src/twig.core.js
+++ b/src/twig.core.js
@@ -910,7 +910,7 @@ module.exports = function (Twig) {
             str = '';
 
         // [].map would be better but it's not supported by IE8-
-        var escaped_output = '';
+        var escaped_output = new Array(len);
         for (i = 0; i < len; i++) {
             str = output[i];
 
@@ -918,13 +918,13 @@ module.exports = function (Twig) {
                 str = Twig.filters.escape(str, [ strategy ]);
             }
 
-            escaped_output += str;
+            escaped_output[i] = str;
         }
 
         if (escaped_output.length < 1)
             return '';
 
-        return Twig.Markup(escaped_output, true);
+        return Twig.Markup(escaped_output.join(""), true);
     }
 
     // Namespace for template storage and retrieval


### PR DESCRIPTION
Resolves https://github.com/twigjs/twig.js/issues/517

There are some intricacies involved in performing an `array.join`, so switched this back to the original (before #492).

```
[undefined,"",null,false].join('') // => "false"
undefined + "" + null + false // => undefinednullfalse
```

I could have changed [it](https://github.com/twigjs/twig.js/pull/518/files#diff-22566ec93dc04f3aa4f038de2fd55f29L921) to `escaped_output += str || ''` but behaviour would have been slightly different, specifically the `false`.