### PR TITLE
Add tests for namespaces in source function

### DIFF
--- a/test/templates/namespaces_@_source.twig
+++ b/test/templates/namespaces_@_source.twig
@@ -1,0 +1,1 @@
+{{ source("@test/namespaces.twig") }}

--- a/test/templates/namespaces_coloncolon_source.twig
+++ b/test/templates/namespaces_coloncolon_source.twig
@@ -1,0 +1,1 @@
+{{ source("test::namespaces.twig") }}

--- a/test/test.namespaces.js
+++ b/test/test.namespaces.js
@@ -15,8 +15,24 @@ describe("Twig.js Namespaces ->", function() {
 
 				done();
             }
-    	});        
+    	});
     });
+
+  it("should support namespaces defined with :: in source method", function(done) {
+    twig({
+      namespaces: { 'test': 'test/templates/namespaces/' },
+      path: 'test/templates/namespaces_coloncolon_source.twig',
+      load: function(template) {
+        // Render the template
+        template.render({
+          test: "yes",
+          flag: true
+        }).should.equal("namespaces");
+
+        done();
+      }
+    });
+  });
 
     it("should support namespaces defined with @", function(done) {
     	twig({
@@ -31,8 +47,24 @@ describe("Twig.js Namespaces ->", function() {
 
 				done();
             }
-    	});        
+    	});
     });
+
+  it("should support namespaces defined with @ in source method", function(done) {
+    twig({
+      namespaces: { 'test': 'test/templates/namespaces/' },
+      path: 'test/templates/namespaces_@_source.twig',
+      load: function(template) {
+        // Render the template
+        template.render({
+          test: "yes",
+          flag: true
+        }).should.equal("namespaces");
+
+        done();
+      }
+    });
+  });
 
 
 });


### PR DESCRIPTION
When using the source function, namespaces are not working:

`{{ source("test::namespaces.twig") }}`

`Template "test::namespaces.twig" is not defined.`

Maybe I am doing something wrong? Are namespaces supposed to work with `includes` only?