### PR TITLE
Fix bugs in the `embed` tag options

### DIFF
--- a/src/twig.logic.js
+++ b/src/twig.logic.js
@@ -1026,7 +1026,7 @@ module.exports = function (Twig) {
              *  Format: {% embed "template.twig" [with {some: 'values'} only] %}
              */
             type: Twig.logic.type.embed,
-            regex: /^embed\s+(.+?)(?:\s|$)(ignore missing(?:\s|$))?(?:with\s+([\S\s]+?))?(?:\s|$)(only)?$/,
+            regex: /^embed\s+(.+?)(?:\s+(ignore missing))?(?:\s+with\s+([\S\s]+?))?(?:\s+(only))?$/,
             next: [
                 Twig.logic.type.endembed
             ],

--- a/test/test.embed.js
+++ b/test/test.embed.js
@@ -36,14 +36,59 @@ describe("Twig.js Embed ->", function() {
                                                                'END'].join('\n') );
     });
 
-    it("should skip an non existant embed flagged wth 'ignore missing'", function() {
-        twig({
-            id:   'embed-ignore-missing',
-            path: 'test/templates/embed-ignore-missing.twig',
-            async: false
+    it('should skip non-existent embeds flagged with "ignore missing"', function() {
+        [
+            '',
+            ' with {}',
+            ' with {} only',
+            ' only'
+        ].forEach(function (options) {
+            twig({
+                allowInlineIncludes: true,
+                data: 'ignore-{% embed "embed-not-there.twig" ignore missing' + options + ' %}{% endembed %}missing'
+            }).render().should.equal('ignore-missing');
         });
-
-        twig({ref: 'embed-ignore-missing'}).render().should.equal( "ignore-missing" );
     });
 
+    it('should include the correct context using "with" and "only"', function() {
+        twig({
+            data: '|{{ foo }}||{{ baz }}|',
+            id: 'embed.twig'
+        });
+
+        [
+            {
+                expected: '|bar||qux|',
+                options: ''
+            },
+            {
+                expected: '|bar||qux|',
+                options: ' with {}'
+            },
+            {
+                expected: '|bar||override|',
+                options: ' with {"baz": "override"}'
+            },
+            {
+                expected: '||||',
+                options: ' only'
+            },
+            {
+                expected: '||||',
+                options: ' with {} only'
+            },
+            {
+                expected: '|override|||',
+                options: ' with {"foo": "override"} only'
+            },
+        ].forEach(function (test) {
+            twig({
+                allowInlineIncludes: true,
+                data: '{% embed "embed.twig"' + test.options + ' %}{% endembed %}'
+            }).render({
+                foo: 'bar',
+                baz: 'qux'
+            }).should.equal(test.expected);
+        });
+    });
 });


### PR DESCRIPTION
There were some issues with using the `ignore missing` option in conjunction with the `only` option.
It turned out to be due to the regex not matching the options correctly and leaving the token with some missing variables. The regex was a little greedy trying to match after each option against the end of the string, which is not necessary.

- This also adds a set of more robust tests for all the available options.