### PR TITLE
[for] fixes empty loop output when containing async call

### DIFF
--- a/src/twig.logic.js
+++ b/src/twig.logic.js
@@ -289,7 +289,7 @@ module.exports = function (Twig) {
                             Twig.Promise.resolve(true) :
                             Twig.expression.parseAsync.call(that, conditional, inner_context);
 
-                        promise.then(function(condition) {
+                        return promise.then(function(condition) {
                             if (!condition)
                                 return;
 
@@ -316,7 +316,7 @@ module.exports = function (Twig) {
                 .then(function(result) {
                     if (Twig.lib.isArray(result)) {
                         len = result.length;
-                        Twig.async.forEach(result, function (value) {
+                        return Twig.async.forEach(result, function (value) {
                             var key = index;
 
                             return loop(key, value);
@@ -328,14 +328,15 @@ module.exports = function (Twig) {
                             keyset = Object.keys(result);
                         }
                         len = keyset.length;
-                        Twig.forEach(keyset, function(key) {
+                        return Twig.async.forEach(keyset, function(key) {
                             // Ignore the _keys property, it's internal to twig.js
                             if (key === "_keys") return;
 
-                            loop(key,  result[key]);
+                            return loop(key,  result[key]);
                         });
                     }
-
+                })
+                .then(function() {
                     // Only allow else statements if no output was generated
                     continue_chain = (output.length === 0);
 

--- a/test/test.async.js
+++ b/test/test.async.js
@@ -134,4 +134,25 @@ describe("Twig.js Async ->", function() {
         });
     });
 
+    describe("Twig.js Control Structures ->", function() {
+        it("should have a loop context item available for arrays", function() {
+            function run(tpl, result) {
+                var test_template = twig({data: tpl});
+                return test_template.renderAsync({
+                    test: [1,2,3,4], 'async': () => Promise.resolve()
+                })
+                .then(res => res.should.equal(result));
+            }
+
+            return Promise.resolve()
+                .then(() => run('{% for key,value in test %}{{async()}}{{ loop.index }}{% endfor %}', '1234'))
+                .then(() => run('{% for key,value in test %}{{async()}}{{ loop.index0 }}{% endfor %}', '0123'))
+                .then(() => run('{% for key,value in test %}{{async()}}{{ loop.revindex }}{% endfor %}', '4321'))
+                .then(() => run('{% for key,value in test %}{{async()}}{{ loop.revindex0 }}{% endfor %}', '3210'))
+                .then(() => run('{% for key,value in test %}{{async()}}{{ loop.length }}{% endfor %}', '4444'))
+                .then(() => run('{% for key,value in test %}{{async()}}{{ loop.first }}{% endfor %}', 'truefalsefalsefalse'))
+                .then(() => run('{% for key,value in test %}{{async()}}{{ loop.last }}{% endfor %}', 'falsefalsefalsetrue'));
+        });
+    });
+
 });


### PR DESCRIPTION
For loops returned empty strings when using async rendering and async calls inside of the `for`-loop body.