### PR TITLE
Improve detection of when a block is in a loop

### DIFF
--- a/src/twig.core.js
+++ b/src/twig.core.js
@@ -1239,6 +1239,7 @@ module.exports = function (Twig) {
             blocks: blocks || {}
         };
         this.extend = null;
+        this.parseStack = [];
     };
 
     Twig.Template.prototype.render = function (context, params, allow_async) {

--- a/test/test.embed.js
+++ b/test/test.embed.js
@@ -1,6 +1,8 @@
 var Twig = Twig || requireUncached("../twig"),
     twig = twig || Twig.twig;
 
+Twig.cache(false);
+
 describe("Twig.js Embed ->", function() {
     // Test loading a template from a remote endpoint
     it("it should load embed and render", function() {
@@ -90,5 +92,17 @@ describe("Twig.js Embed ->", function() {
                 baz: 'qux'
             }).should.equal(test.expected);
         });
+    });
+
+    it('should override blocks in a for loop', function () {
+        twig({
+            data: '<{% block content %}original{% endblock %}>',
+            id: 'embed.twig'
+        });
+
+        twig({
+            allowInlineIncludes: true,
+            data: '{% for i in 1..3 %}{% embed "embed.twig" %}{% block content %}override{% endblock %}{% endembed %}{% endfor %}'
+        }).render().should.equal('<override><override><override>');
     });
 });


### PR DESCRIPTION
- This fixes #519.
- This is a stop-gap fix until I have completed re-implementing how blocks are parsed and handled, which will happen over a couple of PRs to keep things as simple as possible.
- This is a more robust way of checking if a block is being rendered inside of a for loop, working around issues with checking for the `loop` variable on the context since it is not present when excluded using `with` and `only`.
- A test that covers the bug reported in #519 is included.