### PR TITLE
Upgrade to Webpack 4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,3 @@
 language: node_js
 node_js:
-  - 4
   - 6
-

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ A loader is available from [zimmo.be](https://github.com/zimmo-be/twig-loader).
 
 ## Node Usage (npm)
 
-Tested on node >=4.0.
+Tested on node >=6.0.
 
 You can use twig in your app with
 

--- a/package.json
+++ b/package.json
@@ -42,7 +42,8 @@
     "sinon": "^1.17.6",
     "sinon-chai": "^2.8.0",
     "tokenizer": "1.1.x",
-    "webpack": "^1.13.3"
+    "webpack": "^4.6.0",
+    "webpack-cli": "^2.0.15"
   },
   "browser": {
     "fs": false

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,8 +1,10 @@
 var webpack = require('webpack');
+var UglifyJsPlugin = require('uglifyjs-webpack-plugin');
 
 var env = process.env.WEBPACK_ENV;
 
 module.exports = {
+    mode: 'production',
     entry: './src/twig.js',
     target: env === 'browser' ? 'web' : 'node',
     node: {
@@ -16,6 +18,6 @@ module.exports = {
         libraryTarget: 'umd'
     },
     plugins: env === 'browser' ? [
-        new webpack.optimize.UglifyJsPlugin({minimize: true})
+        new UglifyJsPlugin()
     ] : []
 };


### PR DESCRIPTION
I just started using Twig.js and wanted to make some updates to `webpack.config.js` when I realized that we're still on Webpack 1! We should upgrade to the latest version, 4, to open us up to new plugins and performance enhancements.

This doesn't improve anything about the build size right now, but the build time has been reduced about a second.
