### PR TITLE
Added the ability to set default values for macro arguments

### DIFF
--- a/test/templates/macro-defaults.twig
+++ b/test/templates/macro-defaults.twig
@@ -1,0 +1,2 @@
+{% macro make_me_smile(name, slang = 'Howdy') %}{{ slang }} {{ name }}{% endmacro %}
+{% import _self as greet %}{{ greet.make_me_smile('Twigjs') }}

--- a/test/test.macro.js
+++ b/test/test.macro.js
@@ -53,6 +53,16 @@ describe("Twig.js Macro ->", function() {
         twig({ref: 'import-macro-context-self'}).render({ 'greetings': 'Howdy' }).trim().should.equal( 'Howdy Twigjs' );
     });
 
+    it("it should run wrapped macro with default value for a parameter and self reference", function() {
+        twig({
+            id:   'import-macro-defaults-self',
+            path: 'test/templates/macro-defaults.twig',
+            async: false
+        });
+        // Load the template
+        twig({ref: 'import-macro-defaults-self'}).render({ }).trim().should.equal( 'Howdy Twigjs' );
+    });
+
     it("it should run wrapped macro inside blocks", function() {
         twig({
             id:   'import-macro-inside-block',


### PR DESCRIPTION
For Issue #531
Ability to defined default values for macro arguments:

```twig
{% macro input(name, value = "", type = "text", size = 20) %}
    <input type="{{ type }}" name="{{ name }}" value="{{ value|e }}" size="{{ size }}" />
{% endmacro %}
```