### PR TITLE
Extract parse state

### DIFF
--- a/src/twig.async.js
+++ b/src/twig.async.js
@@ -8,8 +8,8 @@ module.exports = function (Twig) {
     var STATE_RESOLVED = 1;
     var STATE_REJECTED = 2;
 
-    Twig.parseAsync = function (tokens, context, blocks) {
-        return Twig.parse.call(this, tokens, context, true, blocks);
+    Twig.ParseState.prototype.parseAsync = function (tokens, context, blocks) {
+        return this.parse(tokens, context, true, blocks);
     }
 
     Twig.expression.parseAsync = function (tokens, context, tokens_are_parameters) {

--- a/src/twig.async.js
+++ b/src/twig.async.js
@@ -17,7 +17,9 @@ module.exports = function (Twig) {
     }
 
     Twig.logic.parseAsync = function (token, context, chain) {
-        return Twig.logic.parse.call(this, token, context, chain, true);
+        var state = this;
+
+        return Twig.logic.parse.call(state.template, token, context, chain, true);
     }
 
     Twig.Template.prototype.renderAsync = function (context, params) {

--- a/src/twig.async.js
+++ b/src/twig.async.js
@@ -8,8 +8,8 @@ module.exports = function (Twig) {
     var STATE_RESOLVED = 1;
     var STATE_REJECTED = 2;
 
-    Twig.parseAsync = function (tokens, context) {
-        return Twig.parse.call(this, tokens, context, true);
+    Twig.parseAsync = function (tokens, context, blocks) {
+        return Twig.parse.call(this, tokens, context, true, blocks);
     }
 
     Twig.expression.parseAsync = function (tokens, context, tokens_are_parameters) {

--- a/src/twig.async.js
+++ b/src/twig.async.js
@@ -19,7 +19,7 @@ module.exports = function (Twig) {
     Twig.logic.parseAsync = function (token, context, chain) {
         var state = this;
 
-        return Twig.logic.parse.call(state.template, token, context, chain, true);
+        return Twig.logic.parse.call(state, token, context, chain, true);
     }
 
     Twig.Template.prototype.renderAsync = function (context, params) {

--- a/src/twig.async.js
+++ b/src/twig.async.js
@@ -13,7 +13,9 @@ module.exports = function (Twig) {
     }
 
     Twig.expression.parseAsync = function (tokens, context, tokens_are_parameters) {
-        return Twig.expression.parse.call(this, tokens, context, tokens_are_parameters, true);
+        var state = this;
+
+        return Twig.expression.parse.call(state, tokens, context, tokens_are_parameters, true);
     }
 
     Twig.logic.parseAsync = function (token, context, chain) {

--- a/src/twig.core.js
+++ b/src/twig.core.js
@@ -1188,6 +1188,7 @@ module.exports = function (Twig) {
     Twig.ParseState = function (template, blocks) {
         this.blocks = blocks || {};
         this.extend = null;
+        this.importedBlocks = [];
         this.nestingStack = [];
         this.template = template;
     }
@@ -1212,7 +1213,7 @@ module.exports = function (Twig) {
         Twig.forEach(Object.keys(importedBlocks), function(key) {
             if (override || state.blocks[key] === undefined) {
                 state.blocks[key] = importedBlocks[key];
-                state.template.importedBlocks.push(key);
+                state.importedBlocks.push(key);
             }
         });
     };
@@ -1283,7 +1284,6 @@ module.exports = function (Twig) {
 
     Twig.Template.prototype.reset = function(blocks) {
         Twig.log.debug("Twig.Template.reset", "Reseting template " + this.id);
-        this.importedBlocks = [];
         this.originalBlockTokens = {};
         this.child = {
             blocks: blocks || {}

--- a/src/twig.core.js
+++ b/src/twig.core.js
@@ -1190,6 +1190,7 @@ module.exports = function (Twig) {
         this.extend = null;
         this.importedBlocks = [];
         this.nestingStack = [];
+        this.originalBlockTokens = {};
         this.template = template;
     }
 
@@ -1284,7 +1285,6 @@ module.exports = function (Twig) {
 
     Twig.Template.prototype.reset = function(blocks) {
         Twig.log.debug("Twig.Template.reset", "Reseting template " + this.id);
-        this.originalBlockTokens = {};
         this.child = {
             blocks: blocks || {}
         };

--- a/src/twig.core.js
+++ b/src/twig.core.js
@@ -820,7 +820,7 @@ module.exports = function (Twig) {
                     break;
 
                 case Twig.token.type.logic:
-                    return Twig.logic.parseAsync.call(that, token.token /*logic_token*/, context, chain)
+                    return Twig.logic.parseAsync.call(state, token.token /*logic_token*/, context, chain)
                         .then(parseTokenLogic);
                     break;
 

--- a/src/twig.core.js
+++ b/src/twig.core.js
@@ -1189,6 +1189,24 @@ module.exports = function (Twig) {
         this.template = template;
     }
 
+    Twig.ParseState.prototype.importBlocks = function(file, override) {
+        var state = this,
+            importTemplate = state.template.importFile(file),
+            key;
+
+        override = override || false;
+
+        importTemplate.render(state.template.context);
+
+        // Mixin blocks
+        Twig.forEach(Object.keys(importTemplate.blocks), function(key) {
+            if (override || state.template.blocks[key] === undefined) {
+                state.template.blocks[key] = importTemplate.blocks[key];
+                state.template.importedBlocks.push(key);
+            }
+        });
+    };
+
     /**
      * Create a new twig.js template.
      *
@@ -1364,25 +1382,6 @@ module.exports = function (Twig) {
         });
 
         return sub_template;
-    };
-
-    Twig.Template.prototype.importBlocks = function(file, override) {
-        var sub_template = this.importFile(file),
-            context = this.context,
-            that = this,
-            key;
-
-        override = override || false;
-
-        sub_template.render(context);
-
-        // Mixin blocks
-        Twig.forEach(Object.keys(sub_template.blocks), function(key) {
-            if (override || that.blocks[key] === undefined) {
-                that.blocks[key] = sub_template.blocks[key];
-                that.importedBlocks.push(key);
-            }
-        });
     };
 
     Twig.Template.prototype.importMacros = function(file) {

--- a/src/twig.core.js
+++ b/src/twig.core.js
@@ -742,20 +742,20 @@ module.exports = function (Twig) {
         });
     };
 
-    function handleException(that, ex) {
-        if (that.options.rethrow) {
+    function handleException(state, ex) {
+        if (state.template.options.rethrow) {
             if (typeof ex === 'string') {
                 ex = new Twig.Error(ex)
             }
 
             if (ex.type == 'TwigException' && !ex.file) {
-                ex.file = that.id;
+                ex.file = state.template.id;
             }
 
             throw ex;
         }
         else {
-            Twig.log.error("Error parsing twig template " + that.id + ": ");
+            Twig.log.error("Error parsing twig template " + state.template.id + ": ");
             if (ex.stack) {
                 Twig.log.error(ex.stack);
             } else {
@@ -777,8 +777,7 @@ module.exports = function (Twig) {
      * @return {string} The parsed template.
      */
     Twig.parse = function (tokens, context, allow_async) {
-        var that = this,
-            state,
+        var state,
             output = [],
 
             // Store any error that might be thrown by the promise chain.
@@ -850,13 +849,13 @@ module.exports = function (Twig) {
             }
         })
         .then(function() {
-            output = Twig.output.call(that, output);
+            output = Twig.output.call(state.template, output);
             is_async = false;
             return output;
         })
         .catch(function(e) {
             if (allow_async)
-                handleException(that, e);
+                handleException(state, e);
 
             err = e;
         });
@@ -868,7 +867,7 @@ module.exports = function (Twig) {
 
         // Handle errors here if we fail synchronously.
         if (err !== null)
-            return handleException(this, err);
+            return handleException(state, err);
 
         // If `allow_async` is not true we should not allow the user
         // to use asynchronous functions or filters.

--- a/src/twig.core.js
+++ b/src/twig.core.js
@@ -181,15 +181,6 @@ module.exports = function (Twig) {
     }
 
     /**
-     * Wrapper for child context objects in Twig.
-     *
-     * @param {Object} context Values to initialize the context with.
-     */
-    Twig.ChildContext = function(context) {
-        return Twig.lib.copy(context);
-    };
-
-    /**
      * Container for methods related to handling high level template tokens
      *      (for example: {{ expression }}, {% logic %}, {# comment #}, raw data)
      */

--- a/src/twig.core.js
+++ b/src/twig.core.js
@@ -1182,6 +1182,7 @@ module.exports = function (Twig) {
         this.context = context || {};
         this.extend = null;
         this.importedBlocks = [];
+        this.macros = {};
         this.nestingStack = [];
         this.originalBlockTokens = {};
         this.template = template;
@@ -1225,7 +1226,6 @@ module.exports = function (Twig) {
     Twig.Template = function ( params ) {
         var data = params.data,
             id = params.id,
-            macros = params.macros || {},
             base = params.base,
             path = params.path,
             url = params.url,
@@ -1257,7 +1257,6 @@ module.exports = function (Twig) {
         this.path   = path;
         this.url    = url;
         this.name   = name;
-        this.macros = macros;
         this.options = options;
 
         if (is('String', data)) {
@@ -1276,11 +1275,6 @@ module.exports = function (Twig) {
 
         context = context || {};
         params = params || {};
-
-        // Clear any previous state
-        if (params.macros) {
-            this.macros = params.macros;
-        }
 
         return Twig.async.potentiallyAsync(this, allow_async, function() {
             return Twig.parseAsync.call(this, this.tokens, context, params.blocks)
@@ -1324,7 +1318,7 @@ module.exports = function (Twig) {
                 } else if (params.output == 'blocks') {
                     return result.state.blocks;
                 } else if (params.output == 'macros') {
-                    return that.macros;
+                    return result.state.macros;
                 } else {
                     return result.output;
                 }
@@ -1369,19 +1363,6 @@ module.exports = function (Twig) {
         });
 
         return sub_template;
-    };
-
-    Twig.Template.prototype.importMacros = function(file) {
-        var url = Twig.path.parsePath(this, file);
-
-        // load remote template
-        var remoteTemplate = Twig.Templates.loadRemote(url, {
-            method: this.getLoaderMethod(),
-            async: false,
-            id: url
-        });
-
-        return remoteTemplate;
     };
 
     Twig.Template.prototype.getLoaderMethod = function() {

--- a/src/twig.core.js
+++ b/src/twig.core.js
@@ -786,7 +786,8 @@ module.exports = function (Twig) {
             // This will be set to is_async if template renders synchronously
             is_async = true,
             promise = null,
-
+            // the final object to be returned
+            result = {},
             // Track logic chains
             chain = true;
 
@@ -799,6 +800,7 @@ module.exports = function (Twig) {
             state = new Twig.ParseState(this);
         }
 
+        result.state = state;
 
         /*
          * Extracted into it's own function such that the function
@@ -849,9 +851,9 @@ module.exports = function (Twig) {
             }
         })
         .then(function() {
-            output = Twig.output.call(state.template, output);
+            result.output = Twig.output.call(state.template, output);
             is_async = false;
-            return output;
+            return result;
         })
         .catch(function(e) {
             if (allow_async)
@@ -874,7 +876,7 @@ module.exports = function (Twig) {
         if (is_async)
             throw new Twig.Error('You are using Twig.js in sync mode in combination with async extensions.');
 
-        return output;
+        return result;
     };
 
     /**
@@ -1277,7 +1279,7 @@ module.exports = function (Twig) {
 
         return Twig.async.potentiallyAsync(this, allow_async, function() {
             return Twig.parseAsync.call(this, this.tokens, this.context)
-            .then(function(output) {
+            .then(function(result) {
                 var ext_template,
                     url;
 
@@ -1313,13 +1315,13 @@ module.exports = function (Twig) {
                 }
 
                 if (!params) {
-                    return output;
+                    return result.output;
                 } else if (params.output == 'blocks') {
                     return that.blocks;
                 } else if (params.output == 'macros') {
                     return that.macros;
                 } else {
-                    return output;
+                    return result.output;
                 }
             });
         });

--- a/src/twig.core.js
+++ b/src/twig.core.js
@@ -1184,6 +1184,7 @@ module.exports = function (Twig) {
      * @param {Twig.Template} template The template that the tokens being parsed are associated with.
      */
     Twig.ParseState = function (template) {
+        this.extend = null;
         this.nestingStack = [];
         this.template = template;
     }
@@ -1260,7 +1261,6 @@ module.exports = function (Twig) {
         this.child = {
             blocks: blocks || {}
         };
-        this.extend = null;
     };
 
     Twig.Template.prototype.render = function (context, params, allow_async) {
@@ -1284,11 +1284,11 @@ module.exports = function (Twig) {
                     url;
 
                 // Does this template extend another
-                if (that.extend) {
+                if (result.state.extend) {
 
                     // check if the template is provided inline
                     if ( that.options.allowInlineIncludes ) {
-                        ext_template = Twig.Templates.load(that.extend);
+                        ext_template = Twig.Templates.load(result.state.extend);
                         if ( ext_template ) {
                             ext_template.options = that.options;
                         }
@@ -1296,7 +1296,7 @@ module.exports = function (Twig) {
 
                     // check for the template file via include
                     if (!ext_template) {
-                        url = Twig.path.parsePath(that, that.extend);
+                        url = Twig.path.parsePath(that, result.state.extend);
 
                         ext_template = Twig.Templates.loadRemote(url, {
                             method: that.getLoaderMethod(),

--- a/src/twig.core.js
+++ b/src/twig.core.js
@@ -778,6 +778,7 @@ module.exports = function (Twig) {
      */
     Twig.parse = function (tokens, context, allow_async) {
         var that = this,
+            state = new Twig.ParseState(this),
             output = [],
 
             // Store any error that might be thrown by the promise chain.
@@ -1164,6 +1165,15 @@ module.exports = function (Twig) {
     function is(type, obj) {
         var clas = Object.prototype.toString.call(obj).slice(8, -1);
         return obj !== undefined && obj !== null && clas === type;
+    }
+
+    /**
+     * Holds all the state associated with a specific call to Twig.parse.
+     *
+     * @param {Twig.Template} template The template that the tokens being parsed are associated with.
+     */
+    Twig.ParseState = function (template) {
+        this.template = template;
     }
 
     /**

--- a/src/twig.core.js
+++ b/src/twig.core.js
@@ -1218,7 +1218,6 @@ module.exports = function (Twig) {
      * Parameters: {
      *      data:   The template, either pre-compiled tokens or a string template
      *      id:     The name of this template
-     *      blocks: Any pre-existing block from a child template
      * }
      *
      * @param {Object} params The template parameters.
@@ -1226,7 +1225,6 @@ module.exports = function (Twig) {
     Twig.Template = function ( params ) {
         var data = params.data,
             id = params.id,
-            blocks = params.blocks,
             macros = params.macros || {},
             base = params.base,
             path = params.path,
@@ -1243,7 +1241,6 @@ module.exports = function (Twig) {
         //     {
         //          id:     The token ID (if any)
         //          tokens: The list of tokens that makes up this template.
-        //          blocks: The list of block this template contains.
         //          base:   The base template (if any)
         //            options:  {
         //                Compiler/parser options
@@ -1263,10 +1260,6 @@ module.exports = function (Twig) {
         this.macros = macros;
         this.options = options;
 
-        this.child = {
-            blocks: blocks || {}
-        };
-
         if (is('String', data)) {
             this.tokens = Twig.prepare.call(this, data);
         } else {
@@ -1285,9 +1278,6 @@ module.exports = function (Twig) {
         params = params || {};
 
         // Clear any previous state
-        this.child = {
-            blocks: {}
-        };
         if (params.macros) {
             this.macros = params.macros;
         }

--- a/src/twig.core.js
+++ b/src/twig.core.js
@@ -1270,7 +1270,9 @@ module.exports = function (Twig) {
         this.macros = macros;
         this.options = options;
 
-        this.reset(blocks);
+        this.child = {
+            blocks: blocks || {}
+        };
 
         if (is('String', data)) {
             this.tokens = Twig.prepare.call(this, data);
@@ -1283,13 +1285,6 @@ module.exports = function (Twig) {
         }
     };
 
-    Twig.Template.prototype.reset = function(blocks) {
-        Twig.log.debug("Twig.Template.reset", "Reseting template " + this.id);
-        this.child = {
-            blocks: blocks || {}
-        };
-    };
-
     Twig.Template.prototype.render = function (context, params, allow_async) {
         var that = this;
 
@@ -1297,7 +1292,9 @@ module.exports = function (Twig) {
         params = params || {};
 
         // Clear any previous state
-        this.reset();
+        this.child = {
+            blocks: {}
+        };
         if (params.macros) {
             this.macros = params.macros;
         }

--- a/src/twig.core.js
+++ b/src/twig.core.js
@@ -778,7 +778,7 @@ module.exports = function (Twig) {
      */
     Twig.parse = function (tokens, context, allow_async) {
         var that = this,
-            state = new Twig.ParseState(this),
+            state,
             output = [],
 
             // Store any error that might be thrown by the promise chain.
@@ -790,6 +790,16 @@ module.exports = function (Twig) {
 
             // Track logic chains
             chain = true;
+
+        if (this instanceof Twig.ParseState) {
+            // the state is already set
+            state = this;
+        } else {
+            // initial call directly on the template
+            // create a new parse state
+            state = new Twig.ParseState(this);
+        }
+
 
         /*
          * Extracted into it's own function such that the function

--- a/src/twig.core.js
+++ b/src/twig.core.js
@@ -789,7 +789,7 @@ module.exports = function (Twig) {
         } else {
             // initial call directly on the template
             // create a new parse state
-            state = new Twig.ParseState(this, blocks);
+            state = new Twig.ParseState(this, context, blocks);
         }
 
         result.state = state;
@@ -1174,10 +1174,12 @@ module.exports = function (Twig) {
      * Holds all the state associated with a specific call to Twig.parse.
      *
      * @param {Twig.Template} template The template that the tokens being parsed are associated with.
+     * @param {Object} context The initial context to use.
      * @param {Object} blocks Blocks that should override any defined while parsing.
      */
-    Twig.ParseState = function (template, blocks) {
+    Twig.ParseState = function (template, context, blocks) {
         this.blocks = blocks || {};
+        this.context = context || {};
         this.extend = null;
         this.importedBlocks = [];
         this.nestingStack = [];
@@ -1195,7 +1197,7 @@ module.exports = function (Twig) {
         importedBlocks = state.template
             .importFile(file)
             .render(
-                state.template.context,
+                state.context,
                 {
                     output: 'blocks'
                 }
@@ -1279,7 +1281,7 @@ module.exports = function (Twig) {
     Twig.Template.prototype.render = function (context, params, allow_async) {
         var that = this;
 
-        this.context = context || {};
+        context = context || {};
         params = params || {};
 
         // Clear any previous state
@@ -1291,7 +1293,7 @@ module.exports = function (Twig) {
         }
 
         return Twig.async.potentiallyAsync(this, allow_async, function() {
-            return Twig.parseAsync.call(this, this.tokens, this.context, params.blocks)
+            return Twig.parseAsync.call(this, this.tokens, context, params.blocks)
             .then(function(result) {
                 var ext_template,
                     url;
@@ -1322,7 +1324,7 @@ module.exports = function (Twig) {
 
                     that.parent = ext_template;
 
-                    return that.parent.renderAsync(that.context, {
+                    return that.parent.renderAsync(context, {
                         blocks: result.state.blocks
                     });
                 }

--- a/src/twig.core.js
+++ b/src/twig.core.js
@@ -1182,6 +1182,7 @@ module.exports = function (Twig) {
      * @param {Twig.Template} template The template that the tokens being parsed are associated with.
      */
     Twig.ParseState = function (template) {
+        this.nestingStack = [];
         this.template = template;
     }
 
@@ -1258,7 +1259,6 @@ module.exports = function (Twig) {
             blocks: blocks || {}
         };
         this.extend = null;
-        this.parseStack = [];
     };
 
     Twig.Template.prototype.render = function (context, params, allow_async) {

--- a/src/twig.core.js
+++ b/src/twig.core.js
@@ -845,7 +845,7 @@ module.exports = function (Twig) {
                 case Twig.token.type.output:
                     Twig.log.debug("Twig.parse: ", "Output token: ", token.stack);
                     // Parse the given expression in the given context
-                    return Twig.expression.parseAsync.call(that, token.stack, context)
+                    return Twig.expression.parseAsync.call(state, token.stack, context)
                         .then(output_push);
             }
         })

--- a/src/twig.expression.js
+++ b/src/twig.expression.js
@@ -607,7 +607,7 @@ module.exports = function (Twig) {
                     params = token.params,
                     state = this;
 
-                stack.push(Twig.filter.call(state.template, token.value, input, params));
+                stack.push(Twig.filter.call(state, token.value, input, params));
             }
         },
         {
@@ -763,7 +763,7 @@ module.exports = function (Twig) {
 
                 return parseParams(state, token.params, context)
                 .then(function(params) {
-                    return Twig.filter.call(state.template, token.value, input, params);
+                    return Twig.filter.call(state, token.value, input, params);
                 })
                 .then(function(value) {
                     stack.push(value);

--- a/src/twig.expression.js
+++ b/src/twig.expression.js
@@ -4,9 +4,9 @@
 module.exports = function (Twig) {
     "use strict";
 
-    function parseParams(thisArg, params, context) {
+    function parseParams(state, params, context) {
         if (params)
-            return Twig.expression.parseAsync.call(thisArg, params, context);
+            return Twig.expression.parseAsync.call(state, params, context);
 
         return Twig.Promise.resolve(false);
     }
@@ -151,9 +151,10 @@ module.exports = function (Twig) {
                 output.push(token);
             },
             parse: function(token, stack, context) {
-                var value = stack.pop();
+                var value = stack.pop(),
+                    state = this;
 
-                return parseParams(this, token.params, context)
+                return parseParams(state, token.params, context)
                 .then(function(params) {
                     var result = Twig.test(token.filter, value, params);
 
@@ -279,12 +280,14 @@ module.exports = function (Twig) {
                 }
             },
             parse: function(token, stack, context) {
+                var state = this;
+
                 if (token.key) {
                     // handle ternary ':' operator
                     stack.push(token);
                 } else if (token.params) {
                     // handle "{(expression):value}"
-                    return Twig.expression.parseAsync.call(this, token.params, context)
+                    return Twig.expression.parseAsync.call(state, token.params, context)
                     .then(function(key) {
                         token.key = key;
                         stack.push(token);
@@ -466,10 +469,11 @@ module.exports = function (Twig) {
             parse: function(token, stack, context) {
                 var new_array = [],
                     array_ended = false,
-                    value = null;
+                    value = null,
+                    state = this;
 
                 if (token.expression) {
-                    return Twig.expression.parseAsync.call(this, token.params, context)
+                    return Twig.expression.parseAsync.call(state, token.params, context)
                     .then(function(value) {
                         stack.push(value);
                     });
@@ -548,10 +552,11 @@ module.exports = function (Twig) {
             parse: function(token, stack, context) {
                 var new_array = [],
                     array_ended = false,
-                    value = null;
+                    value = null,
+                    state = this;
 
                 if (token.expression) {
-                    return Twig.expression.parseAsync.call(this, token.params, context)
+                    return Twig.expression.parseAsync.call(state, token.params, context)
                     .then(function(value) {
                         stack.push(value);
                     });
@@ -599,9 +604,10 @@ module.exports = function (Twig) {
             },
             parse: function(token, stack, context) {
                 var input = stack.pop(),
-                    params = token.params;
+                    params = token.params,
+                    state = this;
 
-                stack.push(Twig.filter.call(this, token.value, input, params));
+                stack.push(Twig.filter.call(state.template, token.value, input, params));
             }
         },
         {
@@ -752,12 +758,12 @@ module.exports = function (Twig) {
                 output.push(token);
             },
             parse: function(token, stack, context) {
-                var that = this,
-                    input = stack.pop();
+                var input = stack.pop(),
+                    state = this;
 
-                return parseParams(this, token.params, context)
+                return parseParams(state, token.params, context)
                 .then(function(params) {
-                    return Twig.filter.call(that, token.value, input, params);
+                    return Twig.filter.call(state.template, token.value, input, params);
                 })
                 .then(function(value) {
                     stack.push(value);
@@ -786,16 +792,15 @@ module.exports = function (Twig) {
                 output.push(token);
             },
             parse: function(token, stack, context) {
-
-                var that = this,
+                var state = this,
                     fn = token.fn,
                     value;
 
-                return parseParams(this, token.params, context)
+                return parseParams(state, token.params, context)
                 .then(function(params) {
                     if (Twig.functions[fn]) {
                         // Get the function from the built-in functions
-                        value = Twig.functions[fn].apply(that, params);
+                        value = Twig.functions[fn].apply(state.template, params);
 
                     } else if (typeof context[fn] == 'function') {
                         // Get the function from the user/context defined functions
@@ -832,8 +837,10 @@ module.exports = function (Twig) {
                 return (Twig.indexOf(Twig.expression.reservedWords, match[0]) < 0);
             },
             parse: function(token, stack, context) {
+                var state = this;
+
                 // Get the variable from the context
-                return Twig.expression.resolveAsync.call(this, context[token.value], context)
+                return Twig.expression.resolveAsync.call(state, context[token.value], context)
                 .then(function(value) {
                     stack.push(value);
                 });
@@ -852,15 +859,15 @@ module.exports = function (Twig) {
                 output.push(token);
             },
             parse: function(token, stack, context, next_token) {
-                var that = this,
+                var state = this,
                     key = token.key,
                     object = stack.pop(),
                     value;
 
-                return parseParams(this, token.params, context)
+                return parseParams(state, token.params, context)
                 .then(function(params) {
                     if (object === null || object === undefined) {
-                        if (that.options.strict_variables) {
+                        if (state.template.options.strict_variables) {
                             throw new Twig.Error("Can't access a key " + key + " on an null or undefined object.");
                         } else {
                             value = undefined;
@@ -883,7 +890,7 @@ module.exports = function (Twig) {
                     }
 
                     // When resolving an expression we need to pass next_token in case the expression is a function
-                    return Twig.expression.resolveAsync.call(that, value, context, params, next_token, object);
+                    return Twig.expression.resolveAsync.call(state, value, context, params, next_token, object);
                 })
                 .then(function(result) {
                     stack.push(result);
@@ -909,21 +916,21 @@ module.exports = function (Twig) {
             },
             parse: function(token, stack, context, next_token) {
                 // Evaluate key
-                var that = this,
+                var state = this,
                     params = null,
                     object,
                     value;
 
-                return parseParams(this, token.params, context)
+                return parseParams(state, token.params, context)
                 .then(function(parameters) {
                     params = parameters;
-                    return Twig.expression.parseAsync.call(that, token.stack, context);
+                    return Twig.expression.parseAsync.call(state, token.stack, context);
                 })
                 .then(function(key) {
                     object = stack.pop();
 
                     if (object === null || object === undefined) {
-                        if (that.options.strict_variables) {
+                        if (state.template.options.strict_variables) {
                             throw new Twig.Error("Can't access a key " + key + " on an null or undefined object.");
                         } else {
                             return null;
@@ -938,7 +945,7 @@ module.exports = function (Twig) {
                     }
 
                     // When resolving an expression we need to pass next_token in case the expression is a function
-                    return Twig.expression.resolveAsync.call(that, value, object, params, next_token);
+                    return Twig.expression.resolveAsync.call(state, value, object, params, next_token);
                 })
                 .then(function(result) {
                     stack.push(result);
@@ -998,6 +1005,8 @@ module.exports = function (Twig) {
      * @param {Object} context The render context.
      */
     Twig.expression.resolveAsync = function(value, context, params, next_token, object) {
+        var state = this;
+
         if (typeof value != 'function')
             return Twig.Promise.resolve(value);
 
@@ -1017,7 +1026,7 @@ module.exports = function (Twig) {
             var tokens_are_parameters = true;
 
             promise = promise.then(function() {
-                return next_token.params && Twig.expression.parseAsync.call(this, next_token.params, context, tokens_are_parameters);
+                return next_token.params && Twig.expression.parseAsync.call(state, next_token.params, context, tokens_are_parameters);
             })
             .then(function(p) {
                 //Clean up the parentheses tokens on the next loop
@@ -1248,7 +1257,7 @@ module.exports = function (Twig) {
      *                  the given expression.
      */
     Twig.expression.parse = function (tokens, context, tokens_are_parameters, allow_async) {
-        var that = this;
+        var state = this;
 
         // If the token isn't an array, make it one.
         if (!Twig.lib.isArray(tokens))
@@ -1259,7 +1268,7 @@ module.exports = function (Twig) {
             loop_token_fixups = [],
             binaryOperator = Twig.expression.type.operator.binary;
 
-        return Twig.async.potentiallyAsync(this, allow_async, function() {
+        return Twig.async.potentiallyAsync(state, allow_async, function() {
             return Twig.async.forEach(tokens, function expressionToken(token, index) {
                 var token_template = null,
                     next_token = null,
@@ -1278,7 +1287,7 @@ module.exports = function (Twig) {
                 token_template = Twig.expression.handler[token.type];
 
                 if (token_template.parse)
-                    result = token_template.parse.call(that, token, stack, context, next_token);
+                    result = token_template.parse.call(state, token, stack, context, next_token);
 
                 //Store any binary tokens for later if we are in a loop.
                 if (token.type === binaryOperator && context.loop) {

--- a/src/twig.expression.js
+++ b/src/twig.expression.js
@@ -800,7 +800,7 @@ module.exports = function (Twig) {
                 .then(function(params) {
                     if (Twig.functions[fn]) {
                         // Get the function from the built-in functions
-                        value = Twig.functions[fn].apply(state.template, params);
+                        value = Twig.functions[fn].apply(state, params);
 
                     } else if (typeof context[fn] == 'function') {
                         // Get the function from the user/context defined functions

--- a/src/twig.filters.js
+++ b/src/twig.filters.js
@@ -722,10 +722,12 @@ module.exports = function (Twig) {
     };
 
     Twig.filter = function(filter, value, params) {
+        var state = this;
+
         if (!Twig.filters[filter]) {
             throw "Unable to find filter " + filter;
         }
-        return Twig.filters[filter].call(this, value, params);
+        return Twig.filters[filter].call(state, value, params);
     };
 
     Twig.filter.extend = function(filter, definition) {

--- a/src/twig.functions.js
+++ b/src/twig.functions.js
@@ -68,7 +68,9 @@ module.exports = function (Twig) {
         },
         dump: function() {
             // Don't pass arguments to `Array.slice`, that is a performance killer
-            var args_i = arguments.length; args = new Array(args_i);
+            var args_i = arguments.length,
+                args = new Array(args_i),
+                state = this;
             while(args_i-- > 0) args[args_i] = arguments[args_i];
 
             var EOL = '\n',
@@ -127,7 +129,7 @@ module.exports = function (Twig) {
                 };
 
             // handle no argument case by dumping the entire render context
-            if (args.length == 0) args.push(this.context);
+            if (args.length == 0) args.push(state.template.context);
 
             Twig.forEach(args, function(variable) {
                 dumpVar(variable);
@@ -157,10 +159,12 @@ module.exports = function (Twig) {
             return dateObj;
         },
         block: function(block) {
-            if (this.originalBlockTokens[block]) {
-                return Twig.logic.parse.call(this, this.originalBlockTokens[block], this.context).output;
+            var state = this;
+
+            if (state.template.originalBlockTokens[block]) {
+                return Twig.logic.parse.call(state, state.template.originalBlockTokens[block], state.template.context).output;
             } else {
-                return this.blocks[block];
+                return state.template.blocks[block];
             }
         },
         parent: function() {
@@ -198,11 +202,13 @@ module.exports = function (Twig) {
             return Twig.lib.min.apply(null, arguments);
         },
         template_from_string: function(template) {
+            var state = this;
+
             if (template === undefined) {
                 template = '';
             }
             return Twig.Templates.parsers.twig({
-                options: this.options,
+                options: state.template.options,
                 data: template
             });
         },

--- a/src/twig.functions.js
+++ b/src/twig.functions.js
@@ -129,7 +129,7 @@ module.exports = function (Twig) {
                 };
 
             // handle no argument case by dumping the entire render context
-            if (args.length == 0) args.push(state.template.context);
+            if (args.length == 0) args.push(state.context);
 
             Twig.forEach(args, function(variable) {
                 dumpVar(variable);
@@ -162,7 +162,7 @@ module.exports = function (Twig) {
             var state = this;
 
             if (state.originalBlockTokens[block]) {
-                return Twig.logic.parse.call(state, state.originalBlockTokens[block], state.template.context).output;
+                return Twig.logic.parse.call(state, state.originalBlockTokens[block], state.context).output;
             } else {
                 return state.blocks[block];
             }

--- a/src/twig.functions.js
+++ b/src/twig.functions.js
@@ -161,8 +161,8 @@ module.exports = function (Twig) {
         block: function(block) {
             var state = this;
 
-            if (state.template.originalBlockTokens[block]) {
-                return Twig.logic.parse.call(state, state.template.originalBlockTokens[block], state.template.context).output;
+            if (state.originalBlockTokens[block]) {
+                return Twig.logic.parse.call(state, state.originalBlockTokens[block], state.template.context).output;
             } else {
                 return state.blocks[block];
             }

--- a/src/twig.functions.js
+++ b/src/twig.functions.js
@@ -164,7 +164,7 @@ module.exports = function (Twig) {
             if (state.template.originalBlockTokens[block]) {
                 return Twig.logic.parse.call(state, state.template.originalBlockTokens[block], state.template.context).output;
             } else {
-                return state.template.blocks[block];
+                return state.blocks[block];
             }
         },
         parent: function() {

--- a/src/twig.logic.js
+++ b/src/twig.logic.js
@@ -590,12 +590,7 @@ module.exports = function (Twig) {
                 }
 
                 return promise.then(function() {
-                    // Check if a child block has been set from a template extending this one.
-                    if (state.template.child.blocks[token.block]) {
-                        output = state.template.child.blocks[token.block];
-                    } else {
-                        output = state.blocks[token.block];
-                    }
+                    output = state.blocks[token.block];
 
                     return {
                         chain: chain,

--- a/src/twig.logic.js
+++ b/src/twig.logic.js
@@ -1161,21 +1161,15 @@ module.exports = function (Twig) {
                         }
                     }
 
-                    // store previous blocks
-                    that._blocks = Twig.lib.copy(that.blocks);
-                    // reset previous blocks
-                    state.blocks = {};
-
-                    // parse tokens. output will be not used
-                    return Twig.parseAsync.call(state, token.output, innerContext)
-                    .then(function() {
-                        // render tempalte with blocks defined in embed block
-                        return template.renderAsync(innerContext, {'blocks': state.blocks});
-                    });
+                    // bind to template instead of the current state so a new parse state
+                    // is created and any defined blocks are created in isolation
+                    return Twig.parseAsync.call(state.template, token.output, innerContext)
+                        .then(function(result) {
+                            // render template with blocks defined in embed block
+                            return template.renderAsync(innerContext, {'blocks': result.state.blocks});
+                        });
                 })
                 .then(function(output) {
-                    // restore previous blocks
-                    that.blocks = Twig.lib.copy(that._blocks);
                     return {
                         chain: chain,
                         output: output

--- a/src/twig.logic.js
+++ b/src/twig.logic.js
@@ -580,7 +580,7 @@ module.exports = function (Twig) {
                             state.blocks[token.block] = block_output;
                         }
 
-                        state.template.originalBlockTokens[token.block] = {
+                        state.originalBlockTokens[token.block] = {
                             type: token.type,
                             block: token.block,
                             output: token.output,

--- a/src/twig.logic.js
+++ b/src/twig.logic.js
@@ -538,7 +538,7 @@ module.exports = function (Twig) {
                     block_output,
                     output,
                     promise = Twig.Promise.resolve(),
-                    isImported = Twig.indexOf(state.template.importedBlocks, token.block) > -1,
+                    isImported = Twig.indexOf(state.importedBlocks, token.block) > -1,
                     hasParent = state.blocks[token.block] && Twig.indexOf(state.blocks[token.block], Twig.placeholders.parent) > -1;
 
                 // detect if in a for loop
@@ -571,7 +571,7 @@ module.exports = function (Twig) {
                     promise = promise.then(function(block_output) {
                         if (isImported) {
                             // once the block is overridden, remove it from the list of imported blocks
-                            state.template.importedBlocks.splice(state.template.importedBlocks.indexOf(token.block), 1);
+                            state.importedBlocks.splice(state.importedBlocks.indexOf(token.block), 1);
                         }
 
                         if (hasParent) {

--- a/src/twig.logic.js
+++ b/src/twig.logic.js
@@ -283,7 +283,7 @@ module.exports = function (Twig) {
                     },
                     // run once for each iteration of the loop
                     loop = function(key, value) {
-                        var inner_context = Twig.ChildContext(context);
+                        var inner_context = Twig.lib.copy(context);
 
                         inner_context[token.value_var] = value;
 
@@ -669,7 +669,7 @@ module.exports = function (Twig) {
             parse: function (token, context, chain) {
                 var template,
                     state = this,
-                    innerContext = Twig.ChildContext(context);
+                    innerContext = Twig.lib.copy(context);
 
                 // Resolve filename
                 return Twig.expression.parseAsync.call(state, token.stack, context)
@@ -773,7 +773,7 @@ module.exports = function (Twig) {
             },
             parse: function logicTypeInclude(token, context, chain) {
                 // Resolve filename
-                var innerContext = token.only ? {} : Twig.ChildContext(context),
+                var innerContext = token.only ? {} : Twig.lib.copy(context),
                     ignoreMissing = token.ignoreMissing,
                     state = this,
                     promise = null,
@@ -1235,7 +1235,7 @@ module.exports = function (Twig) {
                     promise = Twig.Promise.resolve();
 
                 if (!token.only) {
-                    innerContext = Twig.ChildContext(context);
+                    innerContext = Twig.lib.copy(context);
                 }
 
                 if (token.withStack !== undefined) {

--- a/src/twig.logic.js
+++ b/src/twig.logic.js
@@ -534,7 +534,7 @@ module.exports = function (Twig) {
                     hasParent = state.template.blocks[token.block] && Twig.indexOf(state.template.blocks[token.block], Twig.placeholders.parent) > -1;
 
                 // detect if in a for loop
-                Twig.forEach(state.template.parseStack, function (parent_token) {
+                Twig.forEach(state.nestingStack, function (parent_token) {
                     if (parent_token.type == Twig.logic.type.for_) {
                         token.overwrite = true;
                     }
@@ -1409,17 +1409,17 @@ module.exports = function (Twig) {
             if (!token_template.parse)
                 return '';
 
-            state.template.parseStack.unshift(token);
+            state.nestingStack.unshift(token);
             result = token_template.parse.call(state, token, context || {}, chain);
 
             if (Twig.isPromise(result)) {
                 result = result.then(function (result) {
-                    state.template.parseStack.shift();
+                    state.nestingStack.shift();
 
                     return result;
                 })
             } else {
-                state.template.parseStack.shift();
+                state.nestingStack.shift();
             }
 
             return result;

--- a/src/twig.logic.js
+++ b/src/twig.logic.js
@@ -92,7 +92,7 @@ module.exports = function (Twig) {
             parse: function (token, context, chain) {
                 var state = this;
 
-                return Twig.expression.parseAsync.call(state.template, token.stack, context)
+                return Twig.expression.parseAsync.call(state, token.stack, context)
                 .then(function(result) {
                     chain = true;
 
@@ -139,7 +139,7 @@ module.exports = function (Twig) {
             parse: function (token, context, chain) {
                 var state = this;
 
-                return Twig.expression.parseAsync.call(state.template, token.stack, context)
+                return Twig.expression.parseAsync.call(state, token.stack, context)
                 .then(function(result) {
                     if (chain && Twig.lib.boolval(result)) {
                         chain = false;
@@ -288,7 +288,7 @@ module.exports = function (Twig) {
 
                         var promise = conditional === undefined ?
                             Twig.Promise.resolve(true) :
-                            Twig.expression.parseAsync.call(state.template, conditional, inner_context);
+                            Twig.expression.parseAsync.call(state, conditional, inner_context);
 
                         return promise.then(function(condition) {
                             if (!condition)
@@ -313,7 +313,7 @@ module.exports = function (Twig) {
                     };
 
 
-                return Twig.expression.parseAsync.call(state.template, token.expression, context)
+                return Twig.expression.parseAsync.call(state, token.expression, context)
                 .then(function(result) {
                     if (Twig.lib.isArray(result)) {
                         len = result.length;
@@ -388,7 +388,7 @@ module.exports = function (Twig) {
                 var key = token.key,
                     state = this;
 
-                return Twig.expression.parseAsync.call(state.template, token.expression, context)
+                return Twig.expression.parseAsync.call(state, token.expression, context)
                 .then(function(value) {
                     if (value === context) {
                         /*  If storing the context in a variable, it needs to be a clone of the current state of context.
@@ -487,7 +487,7 @@ module.exports = function (Twig) {
                         value: unfiltered
                     }].concat(token.stack);
 
-                    return Twig.expression.parseAsync.call(state.template, stack, context);
+                    return Twig.expression.parseAsync.call(state, stack, context);
                 })
                 .then(function(output) {
                     return {
@@ -543,9 +543,9 @@ module.exports = function (Twig) {
                 // Don't override previous blocks unless they're imported with "use"
                 if (state.template.blocks[token.block] === undefined || isImported || hasParent || token.overwrite) {
                     if (token.expression) {
-                        promise = Twig.expression.parseAsync.call(state.template, token.output, context)
+                        promise = Twig.expression.parseAsync.call(state, token.output, context)
                         .then(function(value) {
-                            return Twig.expression.parseAsync.call(state.template, {
+                            return Twig.expression.parseAsync.call(state, {
                                 type: Twig.expression.type.string,
                                 value: value
                             }, context);
@@ -553,7 +553,7 @@ module.exports = function (Twig) {
                     } else {
                         promise = Twig.parseAsync.call(state, token.output, context)
                         .then(function(value) {
-                            return Twig.expression.parseAsync.call(state.template, {
+                            return Twig.expression.parseAsync.call(state, {
                                 type: Twig.expression.type.string,
                                 value: value
                             }, context);
@@ -664,7 +664,7 @@ module.exports = function (Twig) {
                     innerContext = Twig.ChildContext(context);
 
                 // Resolve filename
-                return Twig.expression.parseAsync.call(state.template, token.stack, context)
+                return Twig.expression.parseAsync.call(state, token.stack, context)
                 .then(function(file) {
                     // Set parent template
                     state.template.extend = file;
@@ -715,7 +715,7 @@ module.exports = function (Twig) {
                 var state = this;
 
                 // Resolve filename
-                return Twig.expression.parseAsync.call(state.template, token.stack, context)
+                return Twig.expression.parseAsync.call(state, token.stack, context)
                 .then(function(file) {
                     // Import blocks
                     state.template.importBlocks(file);
@@ -772,7 +772,7 @@ module.exports = function (Twig) {
                     result = { chain: chain, output: '' };
 
                 if (typeof token.withStack !== 'undefined') {
-                    promise = Twig.expression.parseAsync.call(state.template, token.withStack, context)
+                    promise = Twig.expression.parseAsync.call(state, token.withStack, context)
                     .then(function(withContext) {
                         Twig.lib.extend(innerContext, withContext);
                     });
@@ -782,7 +782,7 @@ module.exports = function (Twig) {
 
                 return promise
                 .then(function() {
-                    return Twig.expression.parseAsync.call(state.template, token.stack, context);
+                    return Twig.expression.parseAsync.call(state, token.stack, context);
                 })
                 .then(function logicTypeIncludeImport(file) {
                     if (file instanceof Twig.Template) {
@@ -982,7 +982,7 @@ module.exports = function (Twig) {
                     return Twig.Promise.resolve(output);
                 }
 
-                return Twig.expression.parseAsync.call(state.template, token.stack, context)
+                return Twig.expression.parseAsync.call(state, token.stack, context)
                 .then(function(file) {
                     return state.template.importFile(file || token.expression);
                 })
@@ -1042,7 +1042,7 @@ module.exports = function (Twig) {
                     promise = Twig.Promise.resolve(state.template.macros);
 
                 if (token.expression !== "_self") {
-                    promise = Twig.expression.parseAsync.call(state.template, token.stack, context)
+                    promise = Twig.expression.parseAsync.call(state, token.stack, context)
                     .then(function(file) {
                         return state.template.importFile(file || token.expression);
                     })
@@ -1121,7 +1121,7 @@ module.exports = function (Twig) {
                 }
 
                 if (token.withStack !== undefined) {
-                    promise = Twig.expression.parseAsync.call(state.template, token.withStack, context)
+                    promise = Twig.expression.parseAsync.call(state, token.withStack, context)
                     .then(function(withContext) {
                         for (i in withContext) {
                             if (withContext.hasOwnProperty(i))
@@ -1133,7 +1133,7 @@ module.exports = function (Twig) {
                 return promise.then(function() {
                     // Allow this function to be cleaned up early
                     promise = null;
-                    return Twig.expression.parseAsync.call(state.template, token.stack, innerContext);
+                    return Twig.expression.parseAsync.call(state, token.stack, innerContext);
                 })
                 .then(function(file) {
                     if (file instanceof Twig.Template) {
@@ -1228,7 +1228,7 @@ module.exports = function (Twig) {
                 }
 
                 if (token.withStack !== undefined) {
-                    promise = Twig.expression.parseAsync.call(state.template, token.withStack, context)
+                    promise = Twig.expression.parseAsync.call(state, token.withStack, context)
                     .then(function(withContext) {
                         for (i in withContext) {
                             if (withContext.hasOwnProperty(i))

--- a/src/twig.logic.js
+++ b/src/twig.logic.js
@@ -539,7 +539,7 @@ module.exports = function (Twig) {
                     output,
                     promise = Twig.Promise.resolve(),
                     isImported = Twig.indexOf(state.template.importedBlocks, token.block) > -1,
-                    hasParent = state.template.blocks[token.block] && Twig.indexOf(state.template.blocks[token.block], Twig.placeholders.parent) > -1;
+                    hasParent = state.blocks[token.block] && Twig.indexOf(state.blocks[token.block], Twig.placeholders.parent) > -1;
 
                 // detect if in a for loop
                 Twig.forEach(state.nestingStack, function (parent_token) {
@@ -549,7 +549,7 @@ module.exports = function (Twig) {
                 });
 
                 // Don't override previous blocks unless they're imported with "use"
-                if (state.template.blocks[token.block] === undefined || isImported || hasParent || token.overwrite) {
+                if (state.blocks[token.block] === undefined || isImported || hasParent || token.overwrite) {
                     if (token.expression) {
                         promise = Twig.expression.parseAsync.call(state, token.output, context)
                         .then(function(value) {
@@ -575,9 +575,9 @@ module.exports = function (Twig) {
                         }
 
                         if (hasParent) {
-                            state.template.blocks[token.block] = Twig.Markup(state.template.blocks[token.block].replace(Twig.placeholders.parent, block_output));
+                            state.blocks[token.block] = Twig.Markup(state.blocks[token.block].replace(Twig.placeholders.parent, block_output));
                         } else {
-                            state.template.blocks[token.block] = block_output;
+                            state.blocks[token.block] = block_output;
                         }
 
                         state.template.originalBlockTokens[token.block] = {
@@ -594,7 +594,7 @@ module.exports = function (Twig) {
                     if (state.template.child.blocks[token.block]) {
                         output = state.template.child.blocks[token.block];
                     } else {
-                        output = state.template.blocks[token.block];
+                        output = state.blocks[token.block];
                     }
 
                     return {
@@ -1169,13 +1169,13 @@ module.exports = function (Twig) {
                     // store previous blocks
                     that._blocks = Twig.lib.copy(that.blocks);
                     // reset previous blocks
-                    state.template.blocks = {};
+                    state.blocks = {};
 
                     // parse tokens. output will be not used
                     return Twig.parseAsync.call(state, token.output, innerContext)
                     .then(function() {
                         // render tempalte with blocks defined in embed block
-                        return template.renderAsync(innerContext, {'blocks': state.template.blocks});
+                        return template.renderAsync(innerContext, {'blocks': state.blocks});
                     });
                 })
                 .then(function(output) {

--- a/src/twig.logic.js
+++ b/src/twig.logic.js
@@ -442,7 +442,7 @@ module.exports = function (Twig) {
                 return Twig.parseAsync.call(state, token.output, context)
                 .then(function(result) {
                     // set on both the global and local context
-                    state.template.context[key] = result.output;
+                    state.context[key] = result.output;
                     context[key] = result.output;
 
                     return {

--- a/src/twig.logic.js
+++ b/src/twig.logic.js
@@ -1396,23 +1396,23 @@ module.exports = function (Twig) {
 
             var token_template = Twig.logic.handler[token.type],
                 result,
-                that = this;
+                state = this;
 
 
             if (!token_template.parse)
                 return '';
 
-            that.parseStack.unshift(token);
-            result = token_template.parse.call(that, token, context || {}, chain);
+            state.template.parseStack.unshift(token);
+            result = token_template.parse.call(state.template, token, context || {}, chain);
 
             if (Twig.isPromise(result)) {
                 result = result.then(function (result) {
-                    that.parseStack.shift();
+                    state.template.parseStack.shift();
 
                     return result;
                 })
             } else {
-                that.parseStack.shift();
+                state.template.parseStack.shift();
             }
 
             return result;

--- a/src/twig.logic.js
+++ b/src/twig.logic.js
@@ -726,7 +726,7 @@ module.exports = function (Twig) {
                 return Twig.expression.parseAsync.call(state, token.stack, context)
                 .then(function(file) {
                     // Import blocks
-                    state.template.importBlocks(file);
+                    state.importBlocks(file);
 
                     return {
                         chain: chain,

--- a/src/twig.logic.js
+++ b/src/twig.logic.js
@@ -99,7 +99,10 @@ module.exports = function (Twig) {
                     if (Twig.lib.boolval(result)) {
                         chain = false;
 
-                        return Twig.parseAsync.call(state, token.output, context);
+                        return Twig.parseAsync.call(state, token.output, context)
+                            .then(function (result) {
+                                return result.output;
+                            });
                     }
 
                     return '';
@@ -144,7 +147,10 @@ module.exports = function (Twig) {
                     if (chain && Twig.lib.boolval(result)) {
                         chain = false;
 
-                        return Twig.parseAsync.call(state, token.output, context);
+                        return Twig.parseAsync.call(state, token.output, context)
+                            .then(function (result) {
+                                return result.output;
+                            });
                     }
 
                     return '';
@@ -175,7 +181,9 @@ module.exports = function (Twig) {
                     state = this;
 
                 if (chain) {
-                    promise = Twig.parseAsync.call(state, token.output, context);
+                    promise = Twig.parseAsync.call(state, token.output, context).then(function (result) {
+                        return result.output;
+                    });
                 }
 
                 return promise.then(function(output) {
@@ -295,8 +303,8 @@ module.exports = function (Twig) {
                                 return;
 
                             return Twig.parseAsync.call(state, token.output, inner_context)
-                            .then(function(o) {
-                                output.push(o);
+                            .then(function(result) {
+                                output.push(result.output);
                                 index += 1;
                             });
                         })
@@ -432,10 +440,10 @@ module.exports = function (Twig) {
                     key = token.key;
 
                 return Twig.parseAsync.call(state, token.output, context)
-                .then(function(value) {
+                .then(function(result) {
                     // set on both the global and local context
-                    state.template.context[key] = value;
-                    context[key] = value;
+                    state.template.context[key] = result.output;
+                    context[key] = result.output;
 
                     return {
                         chain: continue_chain,
@@ -481,10 +489,10 @@ module.exports = function (Twig) {
                 var state = this;
 
                 return Twig.parseAsync.call(state, token.output, context)
-                .then(function(unfiltered) {
+                .then(function(result) {
                     var stack = [{
                         type: Twig.expression.type.string,
-                        value: unfiltered
+                        value: result.output
                     }].concat(token.stack);
 
                     return Twig.expression.parseAsync.call(state, stack, context);
@@ -552,10 +560,10 @@ module.exports = function (Twig) {
                         });
                     } else {
                         promise = Twig.parseAsync.call(state, token.output, context)
-                        .then(function(value) {
+                        .then(function(result) {
                             return Twig.expression.parseAsync.call(state, {
                                 type: Twig.expression.type.string,
-                                value: value
+                                value: result.output
                             }, context);
                         });
                     }
@@ -820,11 +828,11 @@ module.exports = function (Twig) {
 
                 // Parse the output without any filter
                 return Twig.parseAsync.call(state, token.output, context)
-                .then(function(unfiltered) {
+                .then(function(result) {
                     var // A regular expression to find closing and opening tags with spaces between them
                         rBetweenTagSpaces = />\s+</g,
                         // Replace all space between closing and opening html tags
-                        output = unfiltered.replace(rBetweenTagSpaces,'><').trim();
+                        output = result.output.replace(rBetweenTagSpaces,'><').trim();
                         // Rewrap output as a Twig.Markup
                         output = Twig.Markup(output);
                     return {
@@ -926,7 +934,10 @@ module.exports = function (Twig) {
                         }
                     }).then(function () {
                         // Render
-                        return Twig.parseAsync.call(state, token.output, macroContext);
+                        return Twig.parseAsync.call(state, token.output, macroContext)
+                            .then(function (result) {
+                                return result.output;
+                            });;
                     });
                 };
 
@@ -1241,10 +1252,10 @@ module.exports = function (Twig) {
                 .then(function() {
                     return Twig.parseAsync.call(state, token.output, innerContext);
                 })
-                .then(function(output) {
+                .then(function(result) {
                     return {
                         chain: chain,
-                        output: output
+                        output: result.output
                     };
                 });
             }

--- a/src/twig.logic.js
+++ b/src/twig.logic.js
@@ -904,10 +904,10 @@ module.exports = function (Twig) {
             parse: function (token, context, chain) {
                 var state = this;
 
-                state.template.macros[token.macroName] = function() {
+                state.macros[token.macroName] = function() {
                     // Pass global context and other macros
                     var macroContext = {
-                        _self: template.macros
+                        _self: state.macros
                     };
                     // Save arguments
                     var args = Array.prototype.slice.call(arguments);
@@ -984,7 +984,7 @@ module.exports = function (Twig) {
                     output = { chain: chain, output: '' };
 
                 if (token.expression === '_self') {
-                    context[token.contextName] = state.template.macros;
+                    context[token.contextName] = state.macros;
                     return Twig.Promise.resolve(output);
                 }
 
@@ -1045,7 +1045,7 @@ module.exports = function (Twig) {
             },
             parse: function (token, context, chain) {
                 var state = this,
-                    promise = Twig.Promise.resolve(state.template.macros);
+                    promise = Twig.Promise.resolve(state.macros);
 
                 if (token.expression !== "_self") {
                     promise = Twig.expression.parseAsync.call(state, token.stack, context)

--- a/src/twig.logic.js
+++ b/src/twig.logic.js
@@ -675,7 +675,7 @@ module.exports = function (Twig) {
                 return Twig.expression.parseAsync.call(state, token.stack, context)
                 .then(function(file) {
                     // Set parent template
-                    state.template.extend = file;
+                    state.extend = file;
 
                     if (file instanceof Twig.Template) {
                         template = file;

--- a/src/twig.logic.js
+++ b/src/twig.logic.js
@@ -90,16 +90,16 @@ module.exports = function (Twig) {
                 return token;
             },
             parse: function (token, context, chain) {
-                var that = this;
+                var state = this;
 
-                return Twig.expression.parseAsync.call(this, token.stack, context)
+                return Twig.expression.parseAsync.call(state.template, token.stack, context)
                 .then(function(result) {
                     chain = true;
 
                     if (Twig.lib.boolval(result)) {
                         chain = false;
 
-                        return Twig.parseAsync.call(that, token.output, context);
+                        return Twig.parseAsync.call(state, token.output, context);
                     }
 
                     return '';
@@ -137,14 +137,14 @@ module.exports = function (Twig) {
                 return token;
             },
             parse: function (token, context, chain) {
-                var that = this;
+                var state = this;
 
-                return Twig.expression.parseAsync.call(this, token.stack, context)
+                return Twig.expression.parseAsync.call(state.template, token.stack, context)
                 .then(function(result) {
                     if (chain && Twig.lib.boolval(result)) {
                         chain = false;
 
-                        return Twig.parseAsync.call(that, token.output, context);
+                        return Twig.parseAsync.call(state, token.output, context);
                     }
 
                     return '';
@@ -171,10 +171,11 @@ module.exports = function (Twig) {
             ],
             open: false,
             parse: function (token, context, chain) {
-                var promise = Twig.Promise.resolve('');
+                var promise = Twig.Promise.resolve(''),
+                    state = this;
 
                 if (chain) {
-                    promise = Twig.parseAsync.call(this, token.output, context);
+                    promise = Twig.parseAsync.call(state, token.output, context);
                 }
 
                 return promise.then(function(output) {
@@ -257,7 +258,7 @@ module.exports = function (Twig) {
                     len,
                     index = 0,
                     keyset,
-                    that = this,
+                    state = this,
                     conditional = token.conditional,
                     buildLoop = function(index, len) {
                         var isConditional = conditional !== undefined;
@@ -287,13 +288,13 @@ module.exports = function (Twig) {
 
                         var promise = conditional === undefined ?
                             Twig.Promise.resolve(true) :
-                            Twig.expression.parseAsync.call(that, conditional, inner_context);
+                            Twig.expression.parseAsync.call(state.template, conditional, inner_context);
 
                         return promise.then(function(condition) {
                             if (!condition)
                                 return;
 
-                            return Twig.parseAsync.call(that, token.output, inner_context)
+                            return Twig.parseAsync.call(state, token.output, inner_context)
                             .then(function(o) {
                                 output.push(o);
                                 index += 1;
@@ -312,7 +313,7 @@ module.exports = function (Twig) {
                     };
 
 
-                return Twig.expression.parseAsync.call(this, token.expression, context)
+                return Twig.expression.parseAsync.call(state.template, token.expression, context)
                 .then(function(result) {
                     if (Twig.lib.isArray(result)) {
                         len = result.length;
@@ -342,7 +343,7 @@ module.exports = function (Twig) {
 
                     return {
                         chain: continue_chain,
-                        output: Twig.output.call(that, output)
+                        output: Twig.output.call(state.template, output)
                     };
                 });
             }
@@ -384,9 +385,10 @@ module.exports = function (Twig) {
                 return token;
             },
             parse: function (token, context, continue_chain) {
-                var key = token.key;
+                var key = token.key,
+                    state = this;
 
-                return Twig.expression.parseAsync.call(this, token.expression, context)
+                return Twig.expression.parseAsync.call(state.template, token.expression, context)
                 .then(function(value) {
                     if (value === context) {
                         /*  If storing the context in a variable, it needs to be a clone of the current state of context.
@@ -426,13 +428,13 @@ module.exports = function (Twig) {
                 return token;
             },
             parse: function (token, context, continue_chain) {
-                var that = this,
+                var state = this,
                     key = token.key;
 
-                return Twig.parseAsync.call(this, token.output, context)
+                return Twig.parseAsync.call(state, token.output, context)
                 .then(function(value) {
                     // set on both the global and local context
-                    that.context[key] = value;
+                    state.template.context[key] = value;
                     context[key] = value;
 
                     return {
@@ -476,16 +478,16 @@ module.exports = function (Twig) {
                 return token;
             },
             parse: function (token, context, chain) {
-                var that = this;
+                var state = this;
 
-                return Twig.parseAsync.call(this, token.output, context)
+                return Twig.parseAsync.call(state, token.output, context)
                 .then(function(unfiltered) {
                     var stack = [{
                         type: Twig.expression.type.string,
                         value: unfiltered
                     }].concat(token.stack);
 
-                    return Twig.expression.parseAsync.call(that, stack, context);
+                    return Twig.expression.parseAsync.call(state.template, stack, context);
                 })
                 .then(function(output) {
                     return {
@@ -524,34 +526,34 @@ module.exports = function (Twig) {
                 return token;
             },
             parse: function (token, context, chain) {
-                var that = this,
+                var state = this,
                     block_output,
                     output,
                     promise = Twig.Promise.resolve(),
-                    isImported = Twig.indexOf(this.importedBlocks, token.block) > -1,
-                    hasParent = this.blocks[token.block] && Twig.indexOf(this.blocks[token.block], Twig.placeholders.parent) > -1;
+                    isImported = Twig.indexOf(state.template.importedBlocks, token.block) > -1,
+                    hasParent = state.template.blocks[token.block] && Twig.indexOf(state.template.blocks[token.block], Twig.placeholders.parent) > -1;
 
                 // detect if in a for loop
-                Twig.forEach(this.parseStack, function (parent_token) {
+                Twig.forEach(state.template.parseStack, function (parent_token) {
                     if (parent_token.type == Twig.logic.type.for_) {
                         token.overwrite = true;
                     }
                 });
 
                 // Don't override previous blocks unless they're imported with "use"
-                if (this.blocks[token.block] === undefined || isImported || hasParent || token.overwrite) {
+                if (state.template.blocks[token.block] === undefined || isImported || hasParent || token.overwrite) {
                     if (token.expression) {
-                        promise = Twig.expression.parseAsync.call(this, token.output, context)
+                        promise = Twig.expression.parseAsync.call(state.template, token.output, context)
                         .then(function(value) {
-                            return Twig.expression.parseAsync.call(that, {
+                            return Twig.expression.parseAsync.call(state.template, {
                                 type: Twig.expression.type.string,
                                 value: value
                             }, context);
                         });
                     } else {
-                        promise = Twig.parseAsync.call(this, token.output, context)
+                        promise = Twig.parseAsync.call(state, token.output, context)
                         .then(function(value) {
-                            return Twig.expression.parseAsync.call(that, {
+                            return Twig.expression.parseAsync.call(state.template, {
                                 type: Twig.expression.type.string,
                                 value: value
                             }, context);
@@ -561,16 +563,16 @@ module.exports = function (Twig) {
                     promise = promise.then(function(block_output) {
                         if (isImported) {
                             // once the block is overridden, remove it from the list of imported blocks
-                            that.importedBlocks.splice(that.importedBlocks.indexOf(token.block), 1);
+                            state.template.importedBlocks.splice(state.template.importedBlocks.indexOf(token.block), 1);
                         }
 
                         if (hasParent) {
-                            that.blocks[token.block] = Twig.Markup(that.blocks[token.block].replace(Twig.placeholders.parent, block_output));
+                            state.template.blocks[token.block] = Twig.Markup(state.template.blocks[token.block].replace(Twig.placeholders.parent, block_output));
                         } else {
-                            that.blocks[token.block] = block_output;
+                            state.template.blocks[token.block] = block_output;
                         }
 
-                        that.originalBlockTokens[token.block] = {
+                        state.template.originalBlockTokens[token.block] = {
                             type: token.type,
                             block: token.block,
                             output: token.output,
@@ -581,10 +583,10 @@ module.exports = function (Twig) {
 
                 return promise.then(function() {
                     // Check if a child block has been set from a template extending this one.
-                    if (that.child.blocks[token.block]) {
-                        output = that.child.blocks[token.block];
+                    if (state.template.child.blocks[token.block]) {
+                        output = state.template.child.blocks[token.block];
                     } else {
-                        output = that.blocks[token.block];
+                        output = state.template.blocks[token.block];
                     }
 
                     return {
@@ -617,9 +619,11 @@ module.exports = function (Twig) {
                 return token;
             },
             parse: function (token, context, chain) {
-                var args = new Array(arguments.length), args_i = arguments.length;
+                var args = new Array(arguments.length),
+                    args_i = arguments.length,
+                    state = this;
                 while(args_i-- > 0) args[args_i] = arguments[args_i];
-                return Twig.logic.handler[Twig.logic.type.block].parse.apply(this, args);
+                return Twig.logic.handler[Twig.logic.type.block].parse.apply(state, args);
             }
         },
         {
@@ -656,20 +660,20 @@ module.exports = function (Twig) {
             },
             parse: function (token, context, chain) {
                 var template,
-                    that = this,
+                    state = this,
                     innerContext = Twig.ChildContext(context);
 
                 // Resolve filename
-                return Twig.expression.parseAsync.call(this, token.stack, context)
+                return Twig.expression.parseAsync.call(state.template, token.stack, context)
                 .then(function(file) {
                     // Set parent template
-                    that.extend = file;
+                    state.template.extend = file;
 
                     if (file instanceof Twig.Template) {
                         template = file;
                     } else {
                         // Import file
-                        template = that.importFile(file);
+                        template = state.template.importFile(file);
                     }
 
                     // Render the template in case it puts anything in its context
@@ -708,13 +712,13 @@ module.exports = function (Twig) {
                 return token;
             },
             parse: function (token, context, chain) {
-                var that = this;
+                var state = this;
 
                 // Resolve filename
-                return Twig.expression.parseAsync.call(this, token.stack, context)
+                return Twig.expression.parseAsync.call(state.template, token.stack, context)
                 .then(function(file) {
                     // Import blocks
-                    that.importBlocks(file);
+                    state.template.importBlocks(file);
 
                     return {
                         chain: chain,
@@ -763,12 +767,12 @@ module.exports = function (Twig) {
                 // Resolve filename
                 var innerContext = token.only ? {} : Twig.ChildContext(context),
                     ignoreMissing = token.ignoreMissing,
-                    that = this,
+                    state = this,
                     promise = null,
                     result = { chain: chain, output: '' };
 
                 if (typeof token.withStack !== 'undefined') {
-                    promise = Twig.expression.parseAsync.call(this, token.withStack, context)
+                    promise = Twig.expression.parseAsync.call(state.template, token.withStack, context)
                     .then(function(withContext) {
                         Twig.lib.extend(innerContext, withContext);
                     });
@@ -778,7 +782,7 @@ module.exports = function (Twig) {
 
                 return promise
                 .then(function() {
-                    return Twig.expression.parseAsync.call(that, token.stack, context);
+                    return Twig.expression.parseAsync.call(state.template, token.stack, context);
                 })
                 .then(function logicTypeIncludeImport(file) {
                     if (file instanceof Twig.Template) {
@@ -786,7 +790,7 @@ module.exports = function (Twig) {
                     }
 
                     try {
-                        return that.importFile(file).renderAsync(innerContext);
+                        return state.template.importFile(file).renderAsync(innerContext);
                     } catch(err) {
                         if (ignoreMissing)
                             return '';
@@ -812,8 +816,10 @@ module.exports = function (Twig) {
 
             // Parse the html and return it without any spaces between tags
             parse: function (token, context, chain) {
+                var state = this;
+
                 // Parse the output without any filter
-                return Twig.parseAsync.call(this, token.output, context)
+                return Twig.parseAsync.call(state, token.output, context)
                 .then(function(unfiltered) {
                     var // A regular expression to find closing and opening tags with spaces between them
                         rBetweenTagSpaces = />\s+</g,
@@ -893,8 +899,9 @@ module.exports = function (Twig) {
                 return token;
             },
             parse: function (token, context, chain) {
-                var template = this;
-                this.macros[token.macroName] = function() {
+                var state = this;
+
+                state.template.macros[token.macroName] = function() {
                     // Pass global context and other macros
                     var macroContext = {
                         _self: template.macros
@@ -919,7 +926,7 @@ module.exports = function (Twig) {
                         }
                     }).then(function () {
                         // Render
-                        return Twig.parseAsync.call(template, token.output, macroContext);
+                        return Twig.parseAsync.call(state, token.output, macroContext);
                     });
                 };
 
@@ -967,17 +974,17 @@ module.exports = function (Twig) {
                 return token;
             },
             parse: function (token, context, chain) {
-                var that = this,
+                var state = this,
                     output = { chain: chain, output: '' };
 
                 if (token.expression === '_self') {
-                    context[token.contextName] = this.macros;
+                    context[token.contextName] = state.template.macros;
                     return Twig.Promise.resolve(output);
                 }
 
-                return Twig.expression.parseAsync.call(this, token.stack, context)
+                return Twig.expression.parseAsync.call(state.template, token.stack, context)
                 .then(function(file) {
-                    return that.importFile(file || token.expression);
+                    return state.template.importFile(file || token.expression);
                 })
                 .then(function(template) {
                     context[token.contextName] = template.renderAsync({}, {output: 'macros'});
@@ -1031,13 +1038,13 @@ module.exports = function (Twig) {
                 return token;
             },
             parse: function (token, context, chain) {
-                var that = this,
-                    promise = Twig.Promise.resolve(this.macros);
+                var state = this,
+                    promise = Twig.Promise.resolve(state.template.macros);
 
                 if (token.expression !== "_self") {
-                    promise = Twig.expression.parseAsync.call(this, token.stack, context)
+                    promise = Twig.expression.parseAsync.call(state.template, token.stack, context)
                     .then(function(file) {
-                        return that.importFile(file || token.expression);
+                        return state.template.importFile(file || token.expression);
                     })
                     .then(function(template) {
                         return template.renderAsync({}, {output: 'macros'});
@@ -1101,7 +1108,7 @@ module.exports = function (Twig) {
             parse: function (token, context, chain) {
                 // Resolve filename
                 var innerContext = {},
-                    that = this,
+                    state = this,
                     i,
                     template,
                     promise = Twig.Promise.resolve();
@@ -1114,7 +1121,7 @@ module.exports = function (Twig) {
                 }
 
                 if (token.withStack !== undefined) {
-                    promise = Twig.expression.parseAsync.call(this, token.withStack, context)
+                    promise = Twig.expression.parseAsync.call(state.template, token.withStack, context)
                     .then(function(withContext) {
                         for (i in withContext) {
                             if (withContext.hasOwnProperty(i))
@@ -1126,7 +1133,7 @@ module.exports = function (Twig) {
                 return promise.then(function() {
                     // Allow this function to be cleaned up early
                     promise = null;
-                    return Twig.expression.parseAsync.call(that, token.stack, innerContext);
+                    return Twig.expression.parseAsync.call(state.template, token.stack, innerContext);
                 })
                 .then(function(file) {
                     if (file instanceof Twig.Template) {
@@ -1134,7 +1141,7 @@ module.exports = function (Twig) {
                     } else {
                         // Import file
                         try {
-                            template = that.importFile(file);
+                            template = state.template.importFile(file);
                         } catch (err) {
                             if (token.ignoreMissing) {
                                 return '';
@@ -1142,7 +1149,7 @@ module.exports = function (Twig) {
 
                             // Errors preserve references to variables in scope,
                             // this removes `this` from the scope.
-                            that = null;
+                            state = null;
 
                             throw err;
                         }
@@ -1151,13 +1158,13 @@ module.exports = function (Twig) {
                     // store previous blocks
                     that._blocks = Twig.lib.copy(that.blocks);
                     // reset previous blocks
-                    that.blocks = {};
+                    state.template.blocks = {};
 
                     // parse tokens. output will be not used
-                    return Twig.parseAsync.call(that, token.output, innerContext)
+                    return Twig.parseAsync.call(state, token.output, innerContext)
                     .then(function() {
                         // render tempalte with blocks defined in embed block
-                        return template.renderAsync(innerContext, {'blocks': that.blocks});
+                        return template.renderAsync(innerContext, {'blocks': state.template.blocks});
                     });
                 })
                 .then(function(output) {
@@ -1213,7 +1220,7 @@ module.exports = function (Twig) {
                 // Resolve filename
                 var innerContext = {},
                     i,
-                    that = this,
+                    state = this,
                     promise = Twig.Promise.resolve();
 
                 if (!token.only) {
@@ -1221,7 +1228,7 @@ module.exports = function (Twig) {
                 }
 
                 if (token.withStack !== undefined) {
-                    promise = Twig.expression.parseAsync.call(this, token.withStack, context)
+                    promise = Twig.expression.parseAsync.call(state.template, token.withStack, context)
                     .then(function(withContext) {
                         for (i in withContext) {
                             if (withContext.hasOwnProperty(i))
@@ -1232,7 +1239,7 @@ module.exports = function (Twig) {
 
                 return promise
                 .then(function() {
-                    return Twig.parseAsync.call(that, token.output, innerContext);
+                    return Twig.parseAsync.call(state, token.output, innerContext);
                 })
                 .then(function(output) {
                     return {
@@ -1403,7 +1410,7 @@ module.exports = function (Twig) {
                 return '';
 
             state.template.parseStack.unshift(token);
-            result = token_template.parse.call(state.template, token, context || {}, chain);
+            result = token_template.parse.call(state, token, context || {}, chain);
 
             if (Twig.isPromise(result)) {
                 result = result.then(function (result) {

--- a/test/test.extends.js
+++ b/test/test.extends.js
@@ -77,7 +77,7 @@ describe("Twig.js Extensions ->", function() {
 
 	            	if (App.users[App.currentUser].level == level)
 	            	{
-		                output = Twig.parse.apply(this, [token.output, context]);
+                        output = Twig.parse.apply(this, [token.output, context]).output;
 		            }
 
 	                return {

--- a/test/test.extends.js
+++ b/test/test.extends.js
@@ -77,7 +77,7 @@ describe("Twig.js Extensions ->", function() {
 
 	            	if (App.users[App.currentUser].level == level)
 	            	{
-                        output = Twig.parse.apply(this, [token.output, context]).output;
+                        output = this.parse(token.output, context);
 		            }
 
 	                return {


### PR DESCRIPTION
- This is a fairly large PR since the state while parsing a template touches a lot of the code. I have broken it down into smaller commits to hopefully make it easier to follow.
- The reason for this change was discovered while re-implementing how blocks are rendered. I realized that a lot of the issues were due to the fact that the parse "state" was being stored on the template itself. This makes it harder to manage that state and was leading to it being mishandled in multiple places. Especially when the same template was being rendered more than once by being embedded, and even more so when a template was rendering itself, within itself.
- By extracting all the code that pertains specifically to generic parsing of tokens, the state can be nested, initialized, and stored depending on the case that is required internally. Another benefit of this approach is that, depending on conditionals in the template which can change each time a template is parsed, the blocks and macros can be different; which was not necessarily taken into account before.
- The items that were moved to `Twig.ParseState` were: `blocks`, `context` (global parse context), `extend`, `importedBlocks`, `Twig.importBlocks()` `macros`, `nestingStack`, `originalBlockTokens`, `Twig.parseAsync()`, and `Twig.parse()`. A reference to the template related to the tokens being parsed is also stored on it.
- Calls to logic, expression, filter, and function `parse` methods are now bound to `Twig.ParseState` instead of `Twig.Template`. This represents the biggest user-facing change and is a __BREAKING CHANGE__. I believe this would require a major version bump and a note in the docs. Any third-party code that adds functions, filters, tags, or other extensions to the library would need to be updated to properly reference `Twig.ParseState` and `Twig.Template` (which could be accessed as a property on `Twig.ParseState`).
- This is also a __BREAKING CHANGE__ for any third-party code that call the `Twig.parse` and `Twig.parseAsync` functions directly, since they are now on the `Twig.ParseState` prototype.
- This fixes both #287 and #352, including tests for those cases.
- This the last PR needed to prepare for re-implementing the block parsing. I do not believe there will be any breaking changes in that PR.
