### PR TITLE
Fix extend when add is null

### DIFF
--- a/src/twig.lib.js
+++ b/src/twig.lib.js
@@ -48,7 +48,7 @@ module.exports = function(Twig) {
     };
 
     Twig.lib.extend = function (src, add) {
-        var keys = Object.keys(add),
+        var keys = Object.keys(add || {}),
             i;
 
         i = keys.length;

--- a/test/test.lib.js
+++ b/test/test.lib.js
@@ -1,0 +1,34 @@
+var lib = require('../src/twig.lib');
+
+describe("Twig.js Lib ->", function() {
+
+    var twigTest = {}
+    var libTwig = lib(twigTest).lib
+
+    it("should allow extending", function() {
+        var src = {
+            one: 1,
+            two: 2
+        };
+        var add = {
+            three: 3,
+            one: 4
+        };
+        libTwig.extend(src, add).should.eql({
+          one: 4,
+          two: 2,
+          three: 3
+        });
+    });
+
+    it("should allow extending null", function() {
+        var src = {
+            one: 1,
+            two: 2
+        };
+        libTwig.extend(src, null).should.eql({
+          one: 1,
+          two: 2
+        });
+    });
+});


### PR DESCRIPTION
When `add` is null, there would be an exception thrown. Having it force an empty object when add isn't there fixes the issue.