### PR TITLE
add a factory function to get a completely fresh Twig object

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -604,21 +604,6 @@
         "unset-value": "^1.0.0"
       }
     },
-    "caller-path": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/caller-path/-/caller-path-0.1.0.tgz",
-      "integrity": "sha1-lAhe9jWB7NPaqSREqP6U6CV3dR8=",
-      "dev": true,
-      "requires": {
-        "callsites": "^0.2.0"
-      }
-    },
-    "callsites": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/callsites/-/callsites-0.2.0.tgz",
-      "integrity": "sha1-r6uWJikQp/M8GaV3WCXGnzTjUMo=",
-      "dev": true
-    },
     "camelcase": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
@@ -3269,16 +3254,6 @@
       "integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE=",
       "dev": true
     },
-    "require-uncached": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/require-uncached/-/require-uncached-1.0.3.tgz",
-      "integrity": "sha1-Tg1W1slmL9MeQwEcS5WqSZVUIdM=",
-      "dev": true,
-      "requires": {
-        "caller-path": "^0.1.0",
-        "resolve-from": "^1.0.0"
-      }
-    },
     "resolve-cwd": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/resolve-cwd/-/resolve-cwd-2.0.0.tgz",
@@ -3295,12 +3270,6 @@
           "dev": true
         }
       }
-    },
-    "resolve-from": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-1.0.1.tgz",
-      "integrity": "sha1-Jsv+k10a7uq7Kbw/5a6wHpPUQiY=",
-      "dev": true
     },
     "resolve-url": {
       "version": "0.2.1",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,6 @@
   "devDependencies": {
     "chai": "^3.5.0",
     "mocha": "^4.1.0",
-    "require-uncached": "^1.0.3",
     "should": "11.1.x",
     "sinon": "^1.17.6",
     "sinon-chai": "^2.8.0",

--- a/src/twig.factory.js
+++ b/src/twig.factory.js
@@ -1,0 +1,28 @@
+// ## twig.factory.js
+//
+// This file handles creating the Twig library
+module.exports = function factory() {
+    var Twig = {
+        VERSION: '1.12.0',
+    };
+
+    require('./twig.core')(Twig);
+    require('./twig.compiler')(Twig);
+    require('./twig.expression')(Twig);
+    require('./twig.filters')(Twig);
+    require('./twig.functions')(Twig);
+    require('./twig.lib')(Twig);
+    require('./twig.loader.ajax')(Twig);
+    require('./twig.loader.fs')(Twig);
+    require('./twig.logic')(Twig);
+    require('./twig.parser.source')(Twig);
+    require('./twig.parser.twig')(Twig);
+    require('./twig.path')(Twig);
+    require('./twig.tests')(Twig);
+    require('./twig.async')(Twig);
+    require('./twig.exports')(Twig);
+
+    Twig.exports.factory = factory;
+
+    return Twig.exports;
+}

--- a/src/twig.js
+++ b/src/twig.js
@@ -6,24 +6,4 @@
  * @link      https://github.com/twigjs/twig.js
  */
 
-var Twig = {
-    VERSION: '1.12.0'
-};
-
-require('./twig.core')(Twig);
-require('./twig.compiler')(Twig);
-require('./twig.expression')(Twig);
-require('./twig.filters')(Twig);
-require('./twig.functions')(Twig);
-require('./twig.lib')(Twig);
-require('./twig.loader.ajax')(Twig);
-require('./twig.loader.fs')(Twig);
-require('./twig.logic')(Twig);
-require('./twig.parser.source')(Twig);
-require('./twig.parser.twig')(Twig);
-require('./twig.path')(Twig);
-require('./twig.tests')(Twig);
-require('./twig.async')(Twig);
-require('./twig.exports')(Twig);
-
-module.exports = Twig.exports;
+module.exports = require('./twig.factory')();

--- a/test/browser/test.block.js
+++ b/test/browser/test.block.js
@@ -1,4 +1,4 @@
-var Twig = Twig || require("../twig"),
+var Twig = (Twig || require("../twig")).factory(),
     twig = twig || Twig.twig;
 
 describe("Twig.js Blocks ->", function() {
@@ -90,10 +90,10 @@ describe("Twig.js Blocks ->", function() {
                 load: function(template) {
                     template.render({
                         base: "block-function-parent.twig",
-                        val: "abcd" 
+                        val: "abcd"
                     })
                     .should.equal( "Child content = abcd / Result: Child content = abcd" );
-                    
+
                     done();
                 }
             })

--- a/test/browser/test.browser.js
+++ b/test/browser/test.browser.js
@@ -1,4 +1,4 @@
-var Twig = Twig || require("../twig"),
+var Twig = (Twig || require("../twig")).factory(),
     twig = twig || Twig.twig;
 
 describe("Twig.js Browser Loading ->", function() {
@@ -16,7 +16,7 @@ describe("Twig.js Browser Loading ->", function() {
             flag: false
         }).should.equal("Test template = reload\n\n");
     });
-    
+
     it("Should trigger the error callback for a missing template", function(done) {
 
         twig({

--- a/test/browser/test.macro.js
+++ b/test/browser/test.macro.js
@@ -1,4 +1,4 @@
-var Twig = Twig || require("../twig"),
+var Twig = (Twig || require("../twig")).factory(),
     twig = twig || Twig.twig;
 
 describe("Twig.js Macro ->", function() {
@@ -12,7 +12,7 @@ describe("Twig.js Macro ->", function() {
         // Load the template
         twig({ref: 'macro'}).render({ }).should.equal( '' );
     });
-    
+
     it("it should import macro", function() {
         twig({
             id:   'import-macro',

--- a/test/browser/test.namespace.js
+++ b/test/browser/test.namespace.js
@@ -1,4 +1,4 @@
-var Twig = Twig || require("../twig"),
+var Twig = (Twig || require("../twig")).factory(),
     twig = twig || Twig.twig;
 
 describe("Twig.js Namespaces ->", function() {

--- a/test/hooks.js
+++ b/test/hooks.js
@@ -1,1 +1,0 @@
-global.requireUncached = require('require-uncached');

--- a/test/test.allowed_tags.js
+++ b/test/test.allowed_tags.js
@@ -1,4 +1,4 @@
-var Twig = Twig || requireUncached("../twig"),
+var Twig = (Twig || require("../twig")).factory(),
     twig = twig || Twig.twig;
 
 describe("Twig.js striptags filter arguments", function() {

--- a/test/test.async.js
+++ b/test/test.async.js
@@ -1,4 +1,4 @@
-var Twig = Twig || requireUncached("../twig"),
+var Twig = (Twig || require("../twig")).factory(),
     twig = twig || Twig.twig;
 
 describe("Twig.js Async ->", function() {

--- a/test/test.block.js
+++ b/test/test.block.js
@@ -1,4 +1,4 @@
-var Twig = Twig || requireUncached("../twig"),
+var Twig = (Twig || require("../twig")).factory(),
     twig = twig || Twig.twig;
 
 describe("Twig.js Blocks ->", function() {

--- a/test/test.controlStructures.js
+++ b/test/test.controlStructures.js
@@ -1,4 +1,4 @@
-var Twig = Twig || requireUncached("../twig"),
+var Twig = (Twig || require("../twig")).factory(),
     twig = twig || Twig.twig;
 
 describe("Twig.js Control Structures ->", function() {

--- a/test/test.core.js
+++ b/test/test.core.js
@@ -1,4 +1,4 @@
-var Twig = Twig || requireUncached("../twig"),
+var Twig = (Twig || require("../twig")).factory(),
     twig = twig || Twig.twig;
 
 describe("Twig.js Core ->", function() {

--- a/test/test.embed.js
+++ b/test/test.embed.js
@@ -1,4 +1,4 @@
-var Twig = Twig || requireUncached("../twig"),
+var Twig = (Twig || require("../twig")).factory(),
     twig = twig || Twig.twig;
 
 Twig.cache(false);

--- a/test/test.exports.js
+++ b/test/test.exports.js
@@ -1,4 +1,4 @@
-var Twig = Twig || requireUncached("../twig"),
+var Twig = (Twig || require("../twig")).factory(),
     twig = twig || Twig.twig;
 
 describe("Twig.js Exports __express ->", function() {

--- a/test/test.expressions.js
+++ b/test/test.expressions.js
@@ -1,4 +1,4 @@
-var Twig = Twig || requireUncached("../twig"),
+var Twig = (Twig || require("../twig")).factory(),
     twig = twig || Twig.twig;
 
 describe("Twig.js Expressions ->", function() {

--- a/test/test.expressions.operators.js
+++ b/test/test.expressions.operators.js
@@ -1,4 +1,4 @@
-var Twig = Twig || requireUncached("../twig"),
+var Twig = (Twig || require("../twig")).factory(),
     twig = twig || Twig.twig;
 
 describe("Twig.js Expression Operators ->", function() {

--- a/test/test.extends.js
+++ b/test/test.extends.js
@@ -1,4 +1,4 @@
-var Twig = Twig || requireUncached("../twig"),
+var Twig = (Twig || require("../twig")).factory(),
     twig = twig || Twig.twig;
 
 describe("Twig.js Extensions ->", function() {

--- a/test/test.factory.js
+++ b/test/test.factory.js
@@ -1,0 +1,45 @@
+var Twig = (Twig || require("../twig")),
+    FreshTwig = Twig.factory();
+
+describe.only("Twig.js Factory ->", function() {
+
+    Twig.extendFunction("foo", function() {
+        return 'foo';
+    });
+
+    FreshTwig.extendFunction("bar", function() {
+        return 'bar';
+    });
+
+    it("should not have access to extensions on the main Twig object", function() {
+        const fixt_options = {
+            rethrow: true,
+            data: '{{ foo() }}'
+        };
+
+        Twig.twig(fixt_options).render();
+
+        try {
+            FreshTwig.twig(fixt_options).render();
+            throw new Error('should have thrown an error');
+        } catch(err) {
+            err.message.should.equal('foo function does not exist and is not defined in the context');
+        }
+    });
+
+    it("should not leak extensions to the main Twig object", function() {
+        const fixt_options = {
+            rethrow: true,
+            data: '{{ bar() }}'
+        };
+
+        FreshTwig.twig(fixt_options).render();
+
+        try {
+            Twig.twig(fixt_options).render();
+            throw new Error('should have thrown an error');
+        } catch(err) {
+            err.message.should.equal('bar function does not exist and is not defined in the context');
+        }
+    });
+});

--- a/test/test.filters.js
+++ b/test/test.filters.js
@@ -1,4 +1,4 @@
-var Twig = Twig || requireUncached("../twig"),
+var Twig = (Twig || require("../twig")).factory(),
     twig = twig || Twig.twig;
 
 describe("Twig.js Filters ->", function() {

--- a/test/test.fs.js
+++ b/test/test.fs.js
@@ -1,4 +1,4 @@
-var Twig = Twig || requireUncached("../twig"),
+var Twig = (Twig || require("../twig")).factory(),
     twig = twig || Twig.twig;
 
 describe("Twig.js Loader ->", function() {

--- a/test/test.functions.js
+++ b/test/test.functions.js
@@ -1,4 +1,4 @@
-var Twig = Twig || requireUncached("../twig"),
+var Twig = (Twig || require("../twig")).factory(),
     twig = twig || Twig.twig;
 
 describe("Twig.js Functions ->", function() {

--- a/test/test.loaders.js
+++ b/test/test.loaders.js
@@ -1,4 +1,4 @@
-var Twig = Twig || requireUncached("../twig"),
+var Twig = (Twig || require("../twig")).factory(),
     twig = twig || Twig.twig;
 
 describe("Twig.js Loaders ->", function() {
@@ -29,19 +29,19 @@ describe("Twig.js Loaders ->", function() {
         });
         it("should load a simple template from a custom loader", function() {
             twig({
-                method: 'custom', 
+                method: 'custom',
                 name: 'custom_loader_simple'
             }).render({value: 'test succeeded'}).should.equal('the value is: test succeeded');
         });
         it("should load a template that includes another from a custom loader", function() {
             twig({
-                method: 'custom', 
+                method: 'custom',
                 name: 'custom_loader_include'
             }).render({value: 'test succeeded'}).should.equal('include others from the same loader method - the value is: test succeeded');
         });
         it("should load a template that extends another from a custom loader", function() {
             twig({
-                method: 'custom', 
+                method: 'custom',
                 name: 'custom_loader_complex'
             }).render({value: 'test succeeded'}).should.equal('This lets you extend other templates and include others from the same loader method - the value is: test succeeded');
         });

--- a/test/test.logic.js
+++ b/test/test.logic.js
@@ -1,4 +1,4 @@
-var Twig = Twig || requireUncached("../twig"),
+var Twig = (Twig || require("../twig")).factory(),
     twig = twig || Twig.twig;
 
 describe("Twig.js Logic ->", function() {

--- a/test/test.macro.js
+++ b/test/test.macro.js
@@ -1,4 +1,4 @@
-var Twig = Twig || requireUncached("../twig"),
+var Twig = (Twig || require("../twig")).factory(),
     twig = twig || Twig.twig;
 
 describe("Twig.js Macro ->", function() {

--- a/test/test.namespaces.js
+++ b/test/test.namespaces.js
@@ -1,4 +1,4 @@
-var Twig = Twig || requireUncached("../twig"),
+var Twig = (Twig || require("../twig")).factory(),
     twig = twig || Twig.twig;
 
 describe("Twig.js Namespaces ->", function() {

--- a/test/test.options.js
+++ b/test/test.options.js
@@ -1,4 +1,4 @@
-var Twig = Twig || requireUncached("../twig"),
+var Twig = (Twig || require("../twig")).factory(),
     twig = twig || Twig.twig;
 
 describe("Twig.js Optional Functionality ->", function() {

--- a/test/test.parsers.js
+++ b/test/test.parsers.js
@@ -1,4 +1,4 @@
-var Twig = Twig || requireUncached("../twig"),
+var Twig = (Twig || require("../twig")).factory(),
     twig = twig || Twig.twig;
 
 describe("Twig.js Parsers ->", function() {

--- a/test/test.path.js
+++ b/test/test.path.js
@@ -1,4 +1,4 @@
-var Twig = Twig || requireUncached("../twig"),
+var Twig = (Twig || require("../twig")).factory(),
     twig = twig || Twig.twig;
 
 describe("Twig.js Path ->", function() {

--- a/test/test.performance.js
+++ b/test/test.performance.js
@@ -1,4 +1,4 @@
-var Twig = Twig || requireUncached("../twig"),
+var Twig = (Twig || require("../twig")).factory(),
     twig = twig || Twig.twig;
 
 describe("Twig.js Performance Regressions ->", function() {

--- a/test/test.regression.js
+++ b/test/test.regression.js
@@ -1,4 +1,4 @@
-var Twig = Twig || requireUncached("../twig"),
+var Twig = (Twig || require("../twig")).factory(),
     twig = twig || Twig.twig;
 
 describe("Twig.js Regression Tests ->", function() {

--- a/test/test.rethrow.js
+++ b/test/test.rethrow.js
@@ -1,4 +1,4 @@
-var Twig = Twig || requireUncached("../twig"),
+var Twig = (Twig || require("../twig")).factory(),
     twig = twig || Twig.twig;
 
 describe("Twig.js Rethrow ->", function() {

--- a/test/test.tags.js
+++ b/test/test.tags.js
@@ -1,4 +1,4 @@
-var Twig = Twig || requireUncached("../twig"),
+var Twig = (Twig || require("../twig")).factory(),
     twig = twig || Twig.twig;
 
 describe("Twig.js Tags ->", function() {

--- a/test/test.tests.js
+++ b/test/test.tests.js
@@ -1,4 +1,4 @@
-var Twig = Twig || requireUncached("../twig"),
+var Twig = (Twig || require("../twig")).factory(),
     twig = twig || Twig.twig;
 
 describe("Twig.js Tests ->", function() {
@@ -8,19 +8,19 @@ describe("Twig.js Tests ->", function() {
             twig({data: '{{ 1 is empty }}'}).render().should.equal("false" );
             twig({data: '{{ 0 is empty }}'}).render().should.equal("false" );
         });
-        
+
         it("should identify empty strings", function() {
             // String
             twig({data: '{{ "" is empty }}'}).render().should.equal("true" );
             twig({data: '{{ "test" is empty }}'}).render().should.equal("false" );
         });
-        
+
         it("should identify empty arrays", function() {
             // Array
             twig({data: '{{ [] is empty }}'}).render().should.equal("true" );
             twig({data: '{{ ["1"] is empty }}'}).render().should.equal("false" );
         });
-        
+
         it("should identify empty objects", function() {
             // Object
             twig({data: '{{ {} is empty }}'}).render().should.equal("true" );
@@ -28,14 +28,14 @@ describe("Twig.js Tests ->", function() {
             twig({data: '{{ {"a":"b"} is not empty }}'}).render().should.equal("true" );
         });
     });
-        
+
     describe("odd test ->", function() {
         it("should identify a number as odd", function() {
             twig({data: '{{ (1 + 4) is odd }}'}).render().should.equal("true" );
             twig({data: '{{ 6 is odd }}'}).render().should.equal("false" );
         });
     });
-    
+
     describe("even test ->", function() {
         it("should identify a number as even", function() {
             twig({data: '{{ (1 + 4) is even }}'}).render().should.equal("false" );


### PR DESCRIPTION
This adds a `factory` function to the exported Twig object. By calling the `factory` method, one can obtain a fresh Twig object. This means all custom filters, functions, ... will be gone and the developer can start fresh.