### PR TITLE
Add `verbatim` tag

### DIFF
--- a/src/twig.logic.js
+++ b/src/twig.logic.js
@@ -39,7 +39,9 @@ module.exports = function (Twig) {
         embed:     'Twig.logic.type.embed',
         endembed:  'Twig.logic.type.endembed',
         'with':     'Twig.logic.type.with',
-        endwith:  'Twig.logic.type.endwith'
+        endwith:  'Twig.logic.type.endwith',
+        verbatim:     'Twig.logic.type.verbatim',
+        endverbatim:  'Twig.logic.type.endverbatim'
     };
 
 
@@ -1245,6 +1247,30 @@ module.exports = function (Twig) {
         {
             type: Twig.logic.type.endwith,
             regex: /^endwith$/,
+            next: [ ],
+            open: false
+        },
+        {
+            type: Twig.logic.type.verbatim,
+            regex: /^verbatim/,
+            next: [
+                Twig.logic.type.endverbatim
+            ],
+            open: true,
+
+            // Return the output without any parse
+            parse: function (token, context, chain) {
+                return {
+                    chain: chain,
+                    output: context
+                };
+            }
+        },
+
+        // Add the {% endverbatim %} token
+        {
+            type: Twig.logic.type.endverbatim,
+            regex: /^endverbatim$/,
             next: [ ],
             open: false
         }

--- a/test/test.verbatim.js
+++ b/test/test.verbatim.js
@@ -1,0 +1,10 @@
+var Twig = (Twig || require("../twig")).factory(),
+    twig = twig || Twig.twig;
+
+describe("Twig.js Verbatim ->", function () {
+
+    it("should return raw content", function () {
+        twig({data: '{% verbatim %}{{ variable }}{% endverbatim %}'}).render({ 'variable': 42 }).should.equal('{{ variable }}');
+    });
+
+});


### PR DESCRIPTION
Address issue #571

The `verbatim` tag marks sections as being raw text that should not be parsed. For example to put Twig syntax as example into a template you can use this snippet:
```
{% verbatim %}
    <ul>
    {% for item in seq %}
        <li>{{ item }}</li>
    {% endfor %}
    </ul>
{% endverbatim %}
```