### PR TITLE
Autoescaping improvements

### DIFF
--- a/src/twig.core.js
+++ b/src/twig.core.js
@@ -1294,13 +1294,13 @@ module.exports = function (Twig) {
                 }
 
                 if (!params) {
-                    return output;
+                    return output.valueOf();
                 } else if (params.output == 'blocks') {
                     return that.blocks;
                 } else if (params.output == 'macros') {
                     return that.macros;
                 } else {
-                    return output;
+                    return output.valueOf();
                 }
             });
         });

--- a/src/twig.core.js
+++ b/src/twig.core.js
@@ -914,7 +914,8 @@ module.exports = function (Twig) {
         for (i = 0; i < len; i++) {
             str = output[i];
 
-            if (str && (str.twig_markup !== true && str.twig_markup != strategy)) {
+            if (str && (str.twig_markup !== true && str.twig_markup !== strategy)
+                && !(strategy === 'html' && str.twig_markup === 'html_attr')) {
                 str = Twig.filters.escape(str, [ strategy ]);
             }
 

--- a/test/test.core.js
+++ b/test/test.core.js
@@ -382,6 +382,27 @@ describe("Twig.js Core ->", function() {
             }).should.equal('\\x3Ctest\\x3E\\x26\\x3C\\x2Ftest\\x3E');
         });
 
+        it("should not auto escape html_attr within the html strategy", function() {
+            twig({
+                autoescape: 'html',
+                data: "{{ value|escape('html_attr') }}"
+            }).render({
+                value: '" onclick="alert(\\"html_attr\\")"'
+            }).should.equal('&quot;&#x20;onclick&#x3D;&quot;alert&#x28;&#x5C;&quot;html_attr&#x5C;&quot;&#x29;&quot;');
+        });
+
+        it("should return a usable string after autoescaping", function() {
+            var result = twig({
+                autoescape: true,
+                data: '{{ value }}'
+            }).render({
+                value: '<test>&</test>'
+            });
+
+            (typeof result).should.equal('string');
+            result.valueOf().should.equal(result);
+        });
+
         it("should autoescape parent() output correctly", function() {
             twig({id: 'parent1', data: '{% block body %}<p>{{ value }}</p>{% endblock body %}'});
             twig({


### PR DESCRIPTION
Twig.js's autoescaping currently has some potentially unexpected behavior.

When autoescaping, the returned string object has a `twig_markup` value of true, which is unexpected and currently breaks certain usages of the twig module. For instance, you cannot insert this `String` as-is to your DOM, and must first call `.valueOf()`. I've changed the output to always return a properly formatted string, rather than this `String` object. This should not break any existing code, as you can still call `.valueOf()` on this newly returned string.


The more glaring problem however, is that the current version of twig.js doubly-escapes strings marked as `html_attr` with the `html` strategy. PHP Twig does not do this. I've added a fix for this.


Here's a quick demo of the problem. Given this template
```twig
{{ foo }}
{{ bar|escape('html_attr') }}
```

I've written the following test scripts in Node,
```js
let twig = require('./src/twig.js');
let fs = require('fs');

let templateFile = fs.readFileSync('../twig-test/templates/test.html.twig', {encoding: 'utf-8'});
let template = twig.twig({data: templateFile, autoescape: 'html'});
console.log(template.render({foo: '<script>alert("hi!")</script>', bar: '" onclick="alert(\\"html_attr\\")"'}));
```
and in PHP.
```php
<?php

require_once 'vendor/autoload.php';

$loader = new Twig_Loader_Filesystem('templates');
$twig = new Twig_Environment($loader, ['autoescape' => 'html']);
$template = $twig->load('test.html.twig');
echo $template->render(['foo' => '<script>alert("hi!")</script>', 'bar' => '" onclick="alert(\"html_attr\")"']);
```

The Node script output is as follows
```
&lt;script&gt;alert(&quot;hi!&quot;)&lt;/script&gt;
&amp;quot;&amp;#x20;onclick&amp;#x3D;&amp;quot;alert&amp;#x28;&amp;quot;html_attr&amp;quot;&amp;#x29;&amp;quot;
```

while the PHP script outputs

```
&lt;script&gt;alert(&quot;hi!&quot;)&lt;/script&gt;
&quot;&#x20;onclick&#x3D;&quot;alert&#x28;&#x5C;&quot;html_attr&#x5C;&quot;&#x29;&quot;

```

Note that the inverse operation (i.e. escaping as 'html' while using 'html_attr') does double escape in both twig.js and PHP twig.
