### PR TITLE
Reimplementation of  Blocks

### DIFF
--- a/src/twig.async.js
+++ b/src/twig.async.js
@@ -8,8 +8,8 @@ module.exports = function (Twig) {
     var STATE_RESOLVED = 1;
     var STATE_REJECTED = 2;
 
-    Twig.ParseState.prototype.parseAsync = function (tokens, context, blocks) {
-        return this.parse(tokens, context, true, blocks);
+    Twig.ParseState.prototype.parseAsync = function (tokens, context) {
+        return this.parse(tokens, context, true);
     }
 
     Twig.expression.parseAsync = function (tokens, context, tokens_are_parameters) {

--- a/src/twig.core.js
+++ b/src/twig.core.js
@@ -1432,13 +1432,7 @@ module.exports = function (Twig) {
                         );
                     }
 
-                    if (!params) {
-                        return output;
-                    } else if (params.output == 'macros') {
-                        return state.macros;
-                    } else {
-                        return output;
-                    }
+                    return output;
                 });
         });
     };

--- a/src/twig.core.js
+++ b/src/twig.core.js
@@ -1234,6 +1234,25 @@ module.exports = function (Twig) {
     };
 
     /**
+     * Get the closest token of a specific type to the current nest level.
+     *
+     * @param  {String} type  The logic token type
+     *
+     * @return {Object}
+     */
+    Twig.ParseState.prototype.getNestingStackToken = function (type) {
+        var matchingToken;
+
+        Twig.forEach(this.nestingStack, function (token) {
+            if (matchingToken === undefined && token.type == type) {
+                matchingToken = token;
+            }
+        });
+
+        return matchingToken;
+    };
+
+    /**
      * Parse a set of tokens using the current state.
      *
      * @param {Array} tokens The compiled tokens.

--- a/src/twig.functions.js
+++ b/src/twig.functions.js
@@ -158,18 +158,20 @@ module.exports = function (Twig) {
             }
             return dateObj;
         },
-        block: function(block) {
-            var state = this;
+        block: function(blockName) {
+            var block,
+                state = this;
 
-            if (state.originalBlockTokens[block]) {
-                return Twig.logic.parse.call(state, state.originalBlockTokens[block], state.context).output;
-            } else {
-                return state.renderedBlocks[block];
+            block = state.getBlock(blockName);
+
+            if (block !== undefined) {
+                return block.render(state, state.context);
             }
         },
         parent: function() {
-            // Add a placeholder
-            return Twig.placeholders.parent;
+            var state = this;
+
+            return state.getBlock(state.getNestingStackToken(Twig.logic.type.block).blockName, true).render(state, state.context);
         },
         attribute: function(object, method, params) {
             if (Twig.lib.is('Object', object)) {

--- a/src/twig.functions.js
+++ b/src/twig.functions.js
@@ -164,7 +164,7 @@ module.exports = function (Twig) {
             if (state.originalBlockTokens[block]) {
                 return Twig.logic.parse.call(state, state.originalBlockTokens[block], state.context).output;
             } else {
-                return state.blocks[block];
+                return state.renderedBlocks[block];
             }
         },
         parent: function() {

--- a/src/twig.logic.js
+++ b/src/twig.logic.js
@@ -522,70 +522,26 @@ module.exports = function (Twig) {
             ],
             open: true,
             compile: function (token) {
-                token.block = token.match[1].trim();
+                token.blockName = token.match[1].trim();
                 delete token.match;
+
                 return token;
             },
             parse: function (token, context, chain) {
                 var state = this,
-                    block_output,
-                    output,
-                    promise = Twig.Promise.resolve(),
-                    isImported = Twig.indexOf(state.importedBlocks, token.block) > -1,
-                    hasParent = state.renderedBlocks[token.block] && Twig.indexOf(state.renderedBlocks[token.block], Twig.placeholders.parent) > -1;
+                    promise = Twig.Promise.resolve();
 
-                // detect if in a for loop
-                Twig.forEach(state.nestingStack, function (parent_token) {
-                    if (parent_token.type == Twig.logic.type.for_) {
-                        token.overwrite = true;
-                    }
-                });
                 state.template.blockDefinitions[token.blockName] = new Twig.Block(state.template, token);
 
-                // Don't override previous blocks unless they're imported with "use"
-                if (state.renderedBlocks[token.block] === undefined || isImported || hasParent || token.overwrite) {
-                    if (token.expression) {
-                        promise = Twig.expression.parseAsync.call(state, token.output, context)
-                        .then(function(value) {
-                            return Twig.expression.parseAsync.call(state, {
-                                type: Twig.expression.type.string,
-                                value: value
-                            }, context);
-                        });
-                    } else {
-                        promise = state.parseAsync(token.output, context)
-                        .then(function(tokenOutput) {
-                            return Twig.expression.parseAsync.call(state, {
-                                type: Twig.expression.type.string,
-                                value: tokenOutput
-                            }, context);
-                        });
-                    }
-
-                    promise = promise.then(function(block_output) {
-                        if (isImported) {
-                            // once the block is overridden, remove it from the list of imported blocks
-                            state.importedBlocks.splice(state.importedBlocks.indexOf(token.block), 1);
-                        }
-
-                        if (hasParent) {
-                            state.renderedBlocks[token.block] = Twig.Markup(state.renderedBlocks[token.block].replace(Twig.placeholders.parent, block_output));
-                        } else {
-                            state.renderedBlocks[token.block] = block_output;
-                        }
-
-                        state.originalBlockTokens[token.block] = {
-                            type: token.type,
-                            block: token.block,
-                            output: token.output,
-                            overwrite: true
-                        };
-                    });
+                if (
+                    state.template.parentTemplate === null
+                        ||
+                    state.template.parentTemplate instanceof Twig.Template
+                ) {
+                    promise = state.getBlock(token.blockName).render(state, context);
                 }
 
-                return promise.then(function() {
-                    output = state.renderedBlocks[token.block];
-
+                return promise.then(function (output) {
                     return {
                         chain: chain,
                         output: output
@@ -604,16 +560,15 @@ module.exports = function (Twig) {
             next: [ ],
             open: true,
             compile: function (token) {
-                token.expression = token.match[2].trim();
+                var template = this;
 
+                token.expression = token.match[2].trim();
                 token.output = Twig.expression.compile({
                     type: Twig.expression.type.expression,
                     value: token.expression
                 }).stack;
 
-                token.block = token.match[1].trim();
-                delete token.match;
-                return token;
+                return Twig.logic.handler[Twig.logic.type.block].compile.apply(template, arguments);
             },
             parse: function (token, context, chain) {
                 var args = new Array(arguments.length),
@@ -656,21 +611,11 @@ module.exports = function (Twig) {
                 return token;
             },
             parse: function (token, context, chain) {
-                var state = this,
-                    innerContext = Twig.lib.copy(context);
+                var state = this;
 
                 return Twig.expression.parseAsync.call(state, token.stack, context)
                     .then(function(fileName) {
-                        var template = state.template.importFile(fileName);
-
-                        state.parentTemplatePath = fileName;
-
-                        // render the template in case it puts anything in its context
-                        return template.renderAsync(innerContext);
-                    })
-                    .then(function() {
-                        // Extend the parent context with the extended context
-                        Twig.lib.extend(context, innerContext);
+                        state.template.parentTemplate = fileName;
 
                         return {
                             chain: chain,
@@ -703,17 +648,25 @@ module.exports = function (Twig) {
             parse: function (token, context, chain) {
                 var state = this;
 
-                // Resolve filename
                 return Twig.expression.parseAsync.call(state, token.stack, context)
-                .then(function(file) {
-                    // Import blocks
-                    state.importBlocks(file);
+                    .then(function(filePath) {
+                        // create a new state instead of using the current state
+                        // any defined blocks will be created in isolation
+                        var useState,
+                            useTemplate = state.template.importFile(filePath);
 
-                    return {
-                        chain: chain,
-                        output: ''
-                    };
-                });
+                        useState = new Twig.ParseState(useTemplate)
+                        return useState.parseAsync(useTemplate.tokens)
+                            .then(function () {
+                                Twig.lib.extend(state.blocks.imported, useState.getBlocks());
+                            });
+                    })
+                    .then(function() {
+                        return {
+                            chain: chain,
+                            output: ''
+                        };
+                    });
             }
         },
         {
@@ -1095,44 +1048,39 @@ module.exports = function (Twig) {
                 return token;
             },
             parse: function (token, context, chain) {
-                // Resolve filename
-                var innerContext = {},
-                    state = this,
-                    i,
-                    template,
-                    promise = Twig.Promise.resolve();
+                var embedContext = {},
+                    promise = Twig.Promise.resolve(),
+                    state = this;
 
                 if (!token.only) {
-                    for (i in context) {
-                        if (context.hasOwnProperty(i))
-                            innerContext[i] = context[i];
-                    }
+                    embedContext = Twig.lib.copy(context);
                 }
 
                 if (token.withStack !== undefined) {
-                    promise = Twig.expression.parseAsync.call(state, token.withStack, context)
-                    .then(function(withContext) {
-                        for (i in withContext) {
-                            if (withContext.hasOwnProperty(i))
-                                innerContext[i] = withContext[i];
-                        }
+                    promise = Twig.expression.parseAsync.call(state, token.withStack, context).then(function(withContext) {
+                        Twig.lib.extend(embedContext, withContext);
                     });
                 }
 
-                return promise.then(function() {
-                    // Allow this function to be cleaned up early
-                    promise = null;
-                    return Twig.expression.parseAsync.call(state, token.stack, innerContext);
-                })
-                .then(function(file) {
-                    var embedState;
+                return promise
+                    .then(function() {
+                        return Twig.expression.parseAsync.call(state, token.stack, embedContext);
+                    })
+                    .then(function(fileName) {
+                        var embedOverrideTemplate = new Twig.Template({
+                                data: token.output,
+                                id: state.template.id,
+                                base: state.template.base,
+                                path: state.template.path,
+                                url: state.template.url,
+                                name: state.template.name,
+                                method: state.template.method,
+                                options: state.template.options
+                            }),
+                            embedSourceTemplate;
 
-                    if (file instanceof Twig.Template) {
-                        template = file;
-                    } else {
-                        // Import file
                         try {
-                            template = state.template.importFile(file);
+                            embedSourceTemplate = embedOverrideTemplate.importFile(fileName);
                         } catch (err) {
                             if (token.ignoreMissing) {
                                 return '';
@@ -1144,24 +1092,17 @@ module.exports = function (Twig) {
 
                             throw err;
                         }
-                    }
 
-                    // create a new state instead of using the current state
-                    // any defined blocks will be created in isolation
-                    embedState = new Twig.ParseState(state.template);
+                        embedOverrideTemplate.parentTemplate = fileName;
 
-                    return embedState.parseAsync(token.output, innerContext)
-                        .then(function() {
-                            // render template with blocks defined in embed block
-                            return template.renderAsync(innerContext, {'blocks': embedState.renderedBlocks});
-                        });
-                })
-                .then(function(output) {
-                    return {
-                        chain: chain,
-                        output: output
-                    };
-                });
+                        return embedOverrideTemplate.renderAsync(embedContext);
+                    })
+                    .then(function(output) {
+                        return {
+                            chain: chain,
+                            output: output
+                        };
+                    });
             }
         },
         /* Add the {% endembed %} token

--- a/src/twig.logic.js
+++ b/src/twig.logic.js
@@ -531,7 +531,7 @@ module.exports = function (Twig) {
                 var state = this,
                     promise = Twig.Promise.resolve();
 
-                state.template.blockDefinitions[token.blockName] = new Twig.Block(state.template, token);
+                state.template.blocks.defined[token.blockName] = new Twig.Block(state.template, token);
 
                 if (
                     state.template.parentTemplate === null
@@ -658,7 +658,7 @@ module.exports = function (Twig) {
                         useState = new Twig.ParseState(useTemplate)
                         return useState.parseAsync(useTemplate.tokens)
                             .then(function () {
-                                Twig.lib.extend(state.blocks.imported, useState.getBlocks());
+                                Twig.lib.extend(state.template.blocks.imported, useState.getBlocks());
                             });
                     })
                     .then(function() {

--- a/src/twig.logic.js
+++ b/src/twig.logic.js
@@ -532,7 +532,7 @@ module.exports = function (Twig) {
                     output,
                     promise = Twig.Promise.resolve(),
                     isImported = Twig.indexOf(state.importedBlocks, token.block) > -1,
-                    hasParent = state.blocks[token.block] && Twig.indexOf(state.blocks[token.block], Twig.placeholders.parent) > -1;
+                    hasParent = state.renderedBlocks[token.block] && Twig.indexOf(state.renderedBlocks[token.block], Twig.placeholders.parent) > -1;
 
                 // detect if in a for loop
                 Twig.forEach(state.nestingStack, function (parent_token) {
@@ -543,7 +543,7 @@ module.exports = function (Twig) {
                 state.template.blockDefinitions[token.blockName] = new Twig.Block(state.template, token);
 
                 // Don't override previous blocks unless they're imported with "use"
-                if (state.blocks[token.block] === undefined || isImported || hasParent || token.overwrite) {
+                if (state.renderedBlocks[token.block] === undefined || isImported || hasParent || token.overwrite) {
                     if (token.expression) {
                         promise = Twig.expression.parseAsync.call(state, token.output, context)
                         .then(function(value) {
@@ -569,9 +569,9 @@ module.exports = function (Twig) {
                         }
 
                         if (hasParent) {
-                            state.blocks[token.block] = Twig.Markup(state.blocks[token.block].replace(Twig.placeholders.parent, block_output));
+                            state.renderedBlocks[token.block] = Twig.Markup(state.renderedBlocks[token.block].replace(Twig.placeholders.parent, block_output));
                         } else {
-                            state.blocks[token.block] = block_output;
+                            state.renderedBlocks[token.block] = block_output;
                         }
 
                         state.originalBlockTokens[token.block] = {
@@ -584,7 +584,7 @@ module.exports = function (Twig) {
                 }
 
                 return promise.then(function() {
-                    output = state.blocks[token.block];
+                    output = state.renderedBlocks[token.block];
 
                     return {
                         chain: chain,
@@ -1153,7 +1153,7 @@ module.exports = function (Twig) {
                     return embedState.parseAsync(token.output, innerContext)
                         .then(function() {
                             // render template with blocks defined in embed block
-                            return template.renderAsync(innerContext, {'blocks': embedState.blocks});
+                            return template.renderAsync(innerContext, {'blocks': embedState.renderedBlocks});
                         });
                 })
                 .then(function(output) {

--- a/src/twig.logic.js
+++ b/src/twig.logic.js
@@ -655,35 +655,27 @@ module.exports = function (Twig) {
                 return token;
             },
             parse: function (token, context, chain) {
-                var template,
-                    state = this,
+                var state = this,
                     innerContext = Twig.lib.copy(context);
 
-                // Resolve filename
                 return Twig.expression.parseAsync.call(state, token.stack, context)
-                .then(function(file) {
-                    // Set parent template
-                    state.extend = file;
+                    .then(function(fileName) {
+                        var template = state.template.importFile(fileName);
 
-                    if (file instanceof Twig.Template) {
-                        template = file;
-                    } else {
-                        // Import file
-                        template = state.template.importFile(file);
-                    }
+                        state.parentTemplatePath = fileName;
 
-                    // Render the template in case it puts anything in its context
-                    return template.renderAsync(innerContext);
-                })
-                .then(function() {
-                    // Extend the parent context with the extended context
-                    Twig.lib.extend(context, innerContext);
+                        // render the template in case it puts anything in its context
+                        return template.renderAsync(innerContext);
+                    })
+                    .then(function() {
+                        // Extend the parent context with the extended context
+                        Twig.lib.extend(context, innerContext);
 
-                    return {
-                        chain: chain,
-                        output: ''
-                    };
-                });
+                        return {
+                            chain: chain,
+                            output: ''
+                        };
+                    });
             }
         },
         {

--- a/src/twig.logic.js
+++ b/src/twig.logic.js
@@ -540,6 +540,7 @@ module.exports = function (Twig) {
                         token.overwrite = true;
                     }
                 });
+                state.template.blockDefinitions[token.blockName] = new Twig.Block(state.template, token);
 
                 // Don't override previous blocks unless they're imported with "use"
                 if (state.blocks[token.block] === undefined || isImported || hasParent || token.overwrite) {

--- a/test/browser/test.block.js
+++ b/test/browser/test.block.js
@@ -41,20 +41,6 @@ describe("Twig.js Blocks ->", function() {
         });
     });
 
-    it("Should give access to rendered blocks", function(done) {
-        // Test rendering and loading one block
-        twig({
-            id:   'blocks',
-            href: 'templates/blocks.twig',
-
-            load: function(template) {
-                // Render the template with the blocks parameter
-                template.render({ place: "block" }, {output: 'blocks'}).msg.should.equal( "Coming soon to a block near you!" );
-                done();
-            }
-        });
-    });
-
     it("should render nested blocks", function(done) {
         // Test rendering of blocks within blocks
         twig({

--- a/test/test.block.js
+++ b/test/test.block.js
@@ -98,20 +98,6 @@ describe("Twig.js Blocks ->", function() {
         });
     });
 
-    it("should make the contents of blocks available after they're rendered", function(done) {
-        // Test rendering and loading one block
-        twig({
-            id:   'blocks',
-            path: 'test/templates/blocks.twig',
-
-            load: function(template) {
-                // Render the template with the blocks parameter
-                template.render({ place: "block" }, {output: 'blocks'}).msg.should.equal("Coming soon to a block near you!" );
-                done();
-            }
-        });
-    });
-
     it("should render nested blocks", function(done) {
         // Test rendering of blocks within blocks
         twig({

--- a/test/test.block.js
+++ b/test/test.block.js
@@ -149,6 +149,18 @@ describe("Twig.js Blocks ->", function() {
         }).render().should.equal("Title: child");
     });
 
+    it('should override blocks in loop when extending', function () {
+        twig({
+            id: 'block-loop.twig',
+            data: '{% for label in ["foo", "bar", "baz"] %}<{% block content %}base-{{ label }}-{{ loop.index }}{% endblock %}>{% endfor %}'
+        });
+
+        twig({
+            allowInlineIncludes: true,
+            data: '{% extends "block-loop.twig" %}{% block content %}overriding-{{ parent() }}-at-index-{{ loop.index0 }}{% endblock %}'
+        }).render().should.equal('<overriding-base-foo-1-at-index-0><overriding-base-bar-2-at-index-1><overriding-base-baz-3-at-index-2>')
+    });
+
     describe("block function ->", function() {
         it("should render block content from an included block", function(done) {
             twig({
@@ -203,7 +215,6 @@ describe("Twig.js Blocks ->", function() {
             }).render()
             .should.equal("original changed");
         });
-
     });
 
     describe("block shorthand ->", function() {

--- a/test/test.block.js
+++ b/test/test.block.js
@@ -1,7 +1,11 @@
-var Twig = (Twig || require("../twig")).factory(),
-    twig = twig || Twig.twig;
+var factory = require("../twig").factory,
+    twig;
 
 describe("Twig.js Blocks ->", function() {
+    beforeEach(function () {
+        twig = factory().twig;
+    });
+
     // Test loading a template from a remote endpoint
     it("should load a parent template and render the default values", function() {
         twig({
@@ -50,49 +54,6 @@ describe("Twig.js Blocks ->", function() {
                     base: "template.twig",
                     inner: ':value'
                 }).should.equal( "Other Title - body:value:child" );
-                done();
-            }
-        });
-    });
-
-
-    it("should include blocks from another template for horizontal reuse", function(done) {
-        // Test horizontal reuse
-        twig({
-            id:   'use',
-            path: 'test/templates/use.twig',
-
-            load: function(template) {
-                // Load the template
-                template.render({ place: "diner" }).should.equal("Coming soon to a diner near you!" );
-                done();
-            }
-        });
-    });
-
-    it("should allow overriding of included blocks", function(done) {
-        // Test overriding of included blocks
-        twig({
-            id:   'use-override-block',
-            path: 'test/templates/use-override-block.twig',
-
-            load: function(template) {
-                // Load the template
-                template.render({ place: "diner" }).should.equal("Sorry, can't come to a diner today." );
-                done();
-            }
-        });
-    });
-
-    it("should allow overriding of included nested blocks", function(done) {
-        // Test overriding of included blocks
-        twig({
-            id:   'use-override-nested-block',
-            path: 'test/templates/use-override-nested-block.twig',
-
-            load: function(template) {
-                // Load the template
-                template.render().should.equal("parent:new-child1:new-child2");
                 done();
             }
         });
@@ -161,6 +122,98 @@ describe("Twig.js Blocks ->", function() {
         }).render().should.equal('<overriding-base-foo-1-at-index-0><overriding-base-bar-2-at-index-1><overriding-base-baz-3-at-index-2>')
     });
 
+    describe('"use" tag ->', function () {
+        it("should include blocks from another template for horizontal reuse", function(done) {
+            // Test horizontal reuse
+            twig({
+                id:   'use',
+                path: 'test/templates/use.twig',
+
+                load: function(template) {
+                    // Load the template
+                    template.render({ place: "diner" }).should.equal("Coming soon to a diner near you!" );
+                    done();
+                }
+            });
+        });
+
+        it("should allow overriding of included blocks", function(done) {
+            // Test overriding of included blocks
+            twig({
+                id:   'use-override-block',
+                path: 'test/templates/use-override-block.twig',
+
+                load: function(template) {
+                    // Load the template
+                    template.render({ place: "diner" }).should.equal("Sorry, can't come to a diner today." );
+                    done();
+                }
+            });
+        });
+
+        it("should allow overriding of included nested blocks", function(done) {
+            // Test overriding of included blocks
+            twig({
+                id:   'use-override-nested-block',
+                path: 'test/templates/use-override-nested-block.twig',
+
+                load: function(template) {
+                    // Load the template
+                    template.render().should.equal("parent:new-child1:new-child2");
+                    done();
+                }
+            });
+        });
+
+        it('should allow "parent()" call when importing blocks', function () {
+            twig({
+                id: 'blocks.twig',
+                data: '{% block content "blocks.twig" %}'
+            });
+            twig({
+                id: 'base.twig',
+                data: '{% use "blocks.twig" %}{% block content %}base.twig > {{ parent() }}{% endblock %}'
+            })
+
+            twig({
+                allowInlineIncludes: true,
+                data: '{% extends "base.twig" %}{% block content %}main.twig > {{ parent() }}{% endblock %}'
+            }).render().should.equal('main.twig > base.twig > blocks.twig');
+        });
+
+        it('should allow "use" in template with "extends"', function () {
+            twig({
+                id: 'blocks.twig',
+                data: '{% block content "blocks.twig" %}'
+            });
+            twig({
+                id: 'base.twig',
+                data: '<{% block content %}base.twig{% endblock %}><{% block footer %}footer{% endblock %}>'
+            })
+
+            twig({
+                allowInlineIncludes: true,
+                data: '{% extends "base.twig" %}{% use "blocks.twig" %}{% block content %}main.twig - {{ parent() }}{% endblock %}'
+            }).render().should.equal('<main.twig - blocks.twig><footer>');
+        });
+
+        it('should allow "use" in template with "extends" and nested blocks', function () {
+            twig({
+                id: 'blocks.twig',
+                data: '{% block sidebar %}blocks-sidebar{% endblock %}{% block header %}blocks-header{% endblock %}{% block content %}blocks-content{% endblock %}{% block footer %}blocks-footer{% endblock %}{% block masthead %}<blocks-masthead>{% endblock %}'
+            });
+            twig({
+                id: 'base.twig',
+                data: '<{% block sidebar %}base-sidebar{% endblock %}><{% block header %}base-header{% endblock %}><{% block content %}base-content{% endblock %}><{% block footer "base-footer" %}>'
+            });
+
+            twig({
+                allowInlineIncludes: true,
+                data: '{% extends "base.twig" %}{% use "blocks.twig" %}{% block sidebar %}main-sidebar{% endblock %}{% block header %}main-header - {{ parent() }}{% endblock %}{% block footer %}main-footer{% block masthead %}{{ parent() }}{% endblock %}{% endblock %}'
+            }).render().should.equal('<main-sidebar><main-header - blocks-header><blocks-content><main-footer<blocks-masthead>>');
+        });
+    });
+
     describe("block function ->", function() {
         it("should render block content from an included block", function(done) {
             twig({
@@ -227,11 +280,21 @@ describe("Twig.js Blocks ->", function() {
         });
         it("should overload blocks from an extended template using shorthand syntax", function() {
             twig({
+                data: '{% block title %}Default Title{% endblock %} - {% block body %}body{{inner}}{% endblock %}',
+                id: 'template.twig'
+            });
+            twig({
                 allowInlineIncludes: true,
-                data: '{% extends "child-extends" %}{% block title "New Title" %}{% block body "new body uses the " ~ base ~ " template" %}'
-            })
-            .render({ base: "template.twig" })
-            .should.equal( "New Title - new body uses the template.twig template" );
+                data: '{% extends base %}{% block title %}Other Title{% endblock %}{% block body %}child{% endblock %}',
+                id: 'child.twig',
+            });
+
+            twig({
+                allowInlineIncludes: true,
+                data: '{% extends "child.twig" %}{% block title "New Title" %}{% block body "new body uses the " ~ base ~ " template" %}'
+            }).render({
+                base: 'template.twig'
+            }).should.equal('New Title - new body uses the template.twig template');
         });
     });
 });


### PR DESCRIPTION
As mentioned in #550, this is the final PR needed for fixing the biggest issues with blocks.

- This simplifies handling of blocks by more explicitly storing them, depending on how they are encountered while parsing. There are three "types" of blocks when it comes to parsing:
    - `Defined Blocks` - These are blocks which are defined using the `{% block... %}` tag. They are stored on the `Twig.Template` instance where the `block` tag was parsed. They are stored with a reference to this template.
    - `Imported Blocks` - These are blocks which are imported using the `{% use... %}` tag. This includes all the blocks resolved from the template referenced by the `use` tag. They are stored on the `Twig.Template` instance where the `use` tag was parsed.
    - `Override Blocks` - These are blocks which are passed when creating a `Twig.ParseState` instance. This is used internally to render a parent template referenced by an `{% extends... %}` tag. Any blocks defined in the template where the `extends` tag was parsed, will be passed to the `Twig.ParseState` instance used when rendering the parent template in order to override properly.
- The logic for determining what to output when using a `{% block %}` tag, `block()` function, or `parent()` function is now better defined and more consistent. Much of the logic and complexity was removed from the associated `parse` functions in `twig.logic.js` and `twig.function.js`. There are now four methods which handle this logic internally:
    - `Twig.Template.getBlock` - This method attempts to find the first block matching a specified name on the `Twig.Template` instance, in the following order:
        - `Defined Block`
        - `Imported Block`
    - `Twig.Template.getBlocks` - This method returns an object with all the available blocks on the `Twig.Template` instance, using the following precedence:
        - `Defined Blocks`
        - `Imported Blocks`
    - `Twig.ParseState.getBlock` - This method attempts to find the first block matching a specified name in the following order:
        - `Override Block`
        - `Defined Block` or `Imported Block` resolved from the associated template using `Twig.Template.getBlock`
        - When extending, `Defined Block` or `Imported Block` resolved from the parent template using `Twig.Template.getBlock`
    - `Twig.ParseState.getBlocks` - This method returns an object with all the currently available blocks using the following precedence:
        - `Override Blocks`
        - `Defined Blocks` or `Imported Blocks` resolved from the associated template using `Twig.Template.getBlocks`
        - When extending, `Defined Blocks` or `Imported Blocks` resolved from the parent template using `Twig.Template.getBlocks`
- The `output` option has been removed from the `params` argument on the `Twig.Template.render` method (which accepted `blocks` or `macros` as a value) due to unreliability and it no longer being used internally. This is a __BREAKING CHANGE__.
- This includes tests for, and fixes issues #257, #382, and #436.