### PR TITLE
Filter url_encode was extended for objects

### DIFF
--- a/src/twig.filters.js
+++ b/src/twig.filters.js
@@ -138,6 +138,30 @@ module.exports = function (Twig) {
                 return;
             }
 
+            if (Twig.lib.is('Object', value)) {
+                var serialize = function (obj, prefix) {
+                    var result = [];
+                    var keyset = obj._keys || Object.keys(obj);
+
+                    Twig.forEach(keyset, function (key) {
+                        if (!Object.prototype.hasOwnProperty.call(obj, key)) return;
+
+                        var resultKey = prefix ? prefix + '[' + key + ']' : key;
+                        var resultValue = obj[key];
+
+                        result.push(
+                            (Twig.lib.is('Object', resultValue) || Twig.lib.isArray(resultValue)) ?
+                            serialize(resultValue, resultKey) :
+                            encodeURIComponent(resultKey) + '=' + encodeURIComponent(resultValue)
+                        );
+                    });
+
+                    return result.join('&amp;');
+                }
+
+                return serialize(value);
+            }
+
             var result = encodeURIComponent(value);
             result = result.replace("'", "%27");
             return result;

--- a/test/test.filters.js
+++ b/test/test.filters.js
@@ -17,6 +17,10 @@ describe("Twig.js Filters ->", function() {
             var test_template = twig({data: '{{ foo|url_encode() }}' });
             test_template.render(data).should.equal("%3Cfoo%3E%20%5C%26%22%27.%2C-_%3F%2F%C4%B6%C3%A4%E2%82%AC%E5%8F%B0%E5%8C%97%5B%5D%7B%7D%09%0D%0A%08%C2%80" );
         });
+        it("should encode objects to url", function() {
+            var test_template = twig({data: '{{ ({ a: "customer@example.com", b: { c: 123, d: [1, 2, 3] } })|url_encode }}' });
+            test_template.render().should.equal("a=customer%40example.com&amp;b%5Bc%5D=123&amp;b%5Bd%5D%5B0%5D=1&amp;b%5Bd%5D%5B1%5D=2&amp;b%5Bd%5D%5B2%5D=3" );
+        });
     });
     describe("json_encode ->", function() {
         it("should encode strings to json", function() {


### PR DESCRIPTION
The ability to encode an object to URL by the filter `url_encode` was added according to [the Twig PHP](https://twig.symfony.com/doc/2.x/filters/url_encode.html#url-encode).

```javascript
const data = {
    foo: {
        baz: 'bar',
    },
};
const template = twig({ data: '{{ foo|url_encode }}' });

console.log(template.render(data)); // => "foo%5Bbaz%5D=bar"
```
