### PR TITLE
Replace UglifyJs with Terser as the webpack minimizer

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4097,40 +4097,6 @@
       "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
       "dev": true
     },
-    "uglify-js": {
-      "version": "3.5.10",
-      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.5.10.tgz",
-      "integrity": "sha1-ZSvvOfhtnb/WZ0QH7gWl4tNyzy0=",
-      "dev": true,
-      "requires": {
-        "commander": "~2.20.0",
-        "source-map": "~0.6.1"
-      },
-      "dependencies": {
-        "commander": {
-          "version": "2.20.0",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.0.tgz",
-          "integrity": "sha1-1YuytcHuj4ew00ACfp6U4iLFpCI=",
-          "dev": true
-        }
-      }
-    },
-    "uglifyjs-webpack-plugin": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/uglifyjs-webpack-plugin/-/uglifyjs-webpack-plugin-2.1.2.tgz",
-      "integrity": "sha1-cOXDj7LTXuiHlJwqCtsmVsIyltU=",
-      "dev": true,
-      "requires": {
-        "cacache": "^11.2.0",
-        "find-cache-dir": "^2.0.0",
-        "schema-utils": "^1.0.0",
-        "serialize-javascript": "^1.4.0",
-        "source-map": "^0.6.1",
-        "uglify-js": "^3.0.0",
-        "webpack-sources": "^1.1.0",
-        "worker-farm": "^1.5.2"
-      }
-    },
     "union-value": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/union-value/-/union-value-1.0.0.tgz",

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "sinon": "^7.3.2",
     "sinon-chai": "^3.3.0",
     "tokenizer": "1.1.x",
-    "uglifyjs-webpack-plugin": "^2.0.1",
+    "terser-webpack-plugin": "^1.2.3",
     "webpack": "^4.30.0",
     "webpack-cli": "^3.0.3"
   },

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,5 +1,5 @@
 var webpack = require('webpack');
-var UglifyJsPlugin = require('uglifyjs-webpack-plugin');
+var TerserJsPlugin = require('terser-webpack-plugin');
 
 var env = process.env.WEBPACK_ENV;
 
@@ -19,7 +19,7 @@ module.exports = {
     },
     optimization: {
         minimize: true,
-        minimizer: [new UglifyJsPlugin({
+        minimizer: [new TerserJsPlugin({
             include: /\.min\.js$/
         })]
     }


### PR DESCRIPTION
Terser can handle ES6 syntax unlike UglifyJS.