### PR TITLE
Remove Twig.attempt function

### DIFF
--- a/src/twig.async.js
+++ b/src/twig.async.js
@@ -128,9 +128,13 @@ module.exports = function (Twig) {
             return this;
 
         var value = this._value;
-        var result = Twig.attempt(function() {
-            return onRejected(value);
-        }, Twig.Promise.reject);
+
+        var result;
+        try {
+            result = onRejected(value);
+        } catch(err) {
+            result = Twig.Promise.reject(err);
+        }
 
         return Twig.Promise.resolve(result);
     }
@@ -227,23 +231,29 @@ module.exports = function (Twig) {
             if (p._state == STATE_RESOLVED && !hasResolved) {
                 return Twig.Promise.resolve(p._value);
             } else if (p._state === STATE_RESOLVED) {
-                return Twig.attempt(function() {
+                try {
                     return Twig.Promise.resolve(onResolved(p._value));
-                }, Twig.Promise.reject);
+                } catch(err) {
+                    return Twig.Promise.reject(err);
+                }
             }
 
             var hasRejected = typeof onRejected == 'function';
             return Twig.Promise(function thenExecutor(resolve, reject) {
                 append(
                     hasResolved ? function thenResolve(result) {
-                        Twig.attempt(function thenAttemptResolve() {
+                        try {
                             resolve(onResolved(result));
-                        }, reject);
+                        } catch(err) {
+														reject(err)
+												}
                     } : resolve,
                     hasRejected ? function thenReject(err) {
-                        Twig.attempt(function thenAttemptReject() {
+                        try {
                             resolve(onRejected(err));
-                        }, reject);
+                        } catch(err) {
+														reject(err)
+												}
                     } : reject
                 );
             });

--- a/src/twig.core.js
+++ b/src/twig.core.js
@@ -130,15 +130,6 @@ module.exports = function (Twig) {
     };
 
     /**
-     * try/catch in a function causes the entire function body to remain unoptimized.
-     * Use this instead so only ``Twig.attempt` will be left unoptimized.
-     */
-    Twig.attempt = function(fn, exceptionHandler) {
-        try { return fn(); }
-        catch(ex) { return exceptionHandler(ex); }
-    }
-
-    /**
      * Exception thrown by twig.js.
      */
     Twig.Error = function(message, file) {
@@ -509,7 +500,7 @@ module.exports = function (Twig) {
 
     Twig.compile = function (tokens) {
         var self = this;
-        return Twig.attempt(function() {
+        try {
 
             // Output and intermediate stacks
             var output = [],
@@ -723,7 +714,7 @@ module.exports = function (Twig) {
                                 ", expecting one of " + unclosed_token.next);
             }
             return output;
-        }, function(ex) {
+        } catch(ex) {
             if (self.options.rethrow) {
                 if (ex.type == 'TwigException' && !ex.file) {
                     ex.file = self.id;
@@ -739,7 +730,7 @@ module.exports = function (Twig) {
                     Twig.log.error(ex.toString());
                 }
             }
-        });
+        }
     };
 
     function handleException(that, ex) {


### PR DESCRIPTION
The `Twig.attempt` function was used to work around the performance
issues of old versions of the V8 engine in regards to try-catch blocks.
Improvements in recent versions of the V8 engine allow for the
optimization of try-catch blocks.

Therefore, the `Twig.attempt` function is no longer needed.