### PR TITLE
Remove polyfills for Array methods

### DIFF
--- a/src/twig.async.js
+++ b/src/twig.async.js
@@ -241,7 +241,7 @@ module.exports = function (Twig) {
                 handlers = null;
             }
 
-            Twig.forEach(handlers, h => {
+            handlers.forEach(h => {
                 append(h[0], h[1]);
             });
             handlers = null;

--- a/src/twig.core.js
+++ b/src/twig.core.js
@@ -12,113 +12,8 @@ module.exports = function (Twig) {
 
     Twig.noop = function () {};
 
-    Twig.hasIndexOf = Object.hasOwnProperty.call(Array.prototype, 'indexOf');
-
-    /**
-     * Fallback for Array.indexOf for IE8 et al
-     */
-    Twig.indexOf = function (arr, searchElement) {
-        if (Twig.hasIndexOf) {
-            return arr.indexOf(searchElement);
-        }
-
-        if (arr === undefined || arr === null) {
-            throw new TypeError('\'arr\' cannot be null or undefined');
-        }
-
-        const t = [...arr];
-        const len = t.length >>> 0;
-        if (len === 0) {
-            return -1;
-        }
-
-        let n = 0;
-        if (arguments.length > 0) {
-            n = Number(searchElement);
-            if (Number.isNaN(n)) { // Shortcut for verifying if it's NaN
-                n = 0;
-            } else if (n !== 0 && n !== Infinity && n !== -Infinity) {
-                n = (n > 0 || -1) * Math.floor(Math.abs(n));
-            }
-        }
-
-        if (n >= len) {
-            return -1;
-        }
-
-        let k = (n >= 0) ? n : Math.max(len - Math.abs(n), 0);
-        for (; k < len; k++) {
-            if (k in t && t[k] === searchElement) {
-                return k;
-            }
-        }
-
-        if (arr === searchElement) {
-            return 0;
-        }
-
-        return -1;
-    };
-
-    Twig.forEach = function (arr, callback, thisArg) {
-        if (Array.prototype.forEach) {
-            return arr.forEach(callback, thisArg);
-        }
-
-        let T;
-        let k;
-
-        if (arr === null) {
-            throw new TypeError(' this is null or not defined');
-        }
-
-        // 1. Let O be the result of calling ToObject passing the |this| value as the argument.
-        const O = [...arr];
-
-        // 2. Let lenValue be the result of calling the Get internal method of O with the argument "length".
-        // 3. Let len be ToUint32(lenValue).
-        const len = O.length >>> 0; // Hack to convert O.length to a UInt32
-
-        // 4. If IsCallable(callback) is false, throw a TypeError exception.
-        // See: http://es5.github.com/#x9.11
-        if ({}.toString.call(callback) !== '[object Function]') {
-            throw new TypeError(callback + ' is not a function');
-        }
-
-        // 5. If thisArg was supplied, let T be thisArg; else let T be undefined.
-        if (thisArg) {
-            T = thisArg;
-        }
-
-        // 6. Let k be 0
-        k = 0;
-
-        // 7. Repeat, while k < len
-        while (k < len) {
-            let kValue;
-
-            // A. Let Pk be ToString(k).
-            //   This is implicit for LHS operands of the in operator
-            // B. Let kPresent be the result of calling the HasProperty internal method of O with argument Pk.
-            //   This step can be combined with c
-            // C. If kPresent is true, then
-            if (k in O) {
-                // I. Let kValue be the result of calling the Get internal method of O with argument Pk.
-                kValue = O[k];
-
-                // II. Call the Call internal method of callback with T as the this value and
-                // argument list containing kValue, k, and O.
-                callback.call(T, kValue, k, O);
-            }
-            // D. Increase k by 1.
-
-            k++;
-        }
-        // 8. return undefined
-    };
-
     Twig.merge = function (target, source, onlyChanged) {
-        Twig.forEach(Object.keys(source), key => {
+        Object.keys(source).forEach(key => {
             if (onlyChanged && !(key in target)) {
                 return;
             }
@@ -552,7 +447,7 @@ module.exports = function (Twig) {
                     prevToken = stack.pop();
                     prevTemplate = Twig.logic.handler[prevToken.type];
 
-                    if (Twig.indexOf(prevTemplate.next, type) < 0) {
+                    if (prevTemplate.next.indexOf(type) < 0) {
                         throw new Error(type + ' not expected after a ' + prevToken.type);
                     }
 
@@ -1202,7 +1097,7 @@ module.exports = function (Twig) {
     Twig.ParseState.prototype.getNestingStackToken = function (type) {
         let matchingToken;
 
-        Twig.forEach(this.nestingStack, token => {
+        this.nestingStack.forEach(token => {
             if (matchingToken === undefined && token.type === type) {
                 matchingToken = token;
             }

--- a/src/twig.expression.js
+++ b/src/twig.expression.js
@@ -489,7 +489,7 @@ module.exports = function (Twig) {
             validate(match, tokens) {
                 const lastToken = tokens[tokens.length - 1];
                 // We can't use the regex to test if we follow a space because expression is trimmed
-                return lastToken && (Twig.indexOf(Twig.expression.reservedWords, lastToken.value.trim()) < 0);
+                return lastToken && (Twig.expression.reservedWords.indexOf(lastToken.value.trim()) < 0);
             },
             compile: Twig.expression.fn.compile.pushBoth,
             parse: Twig.expression.fn.parse.push
@@ -782,7 +782,7 @@ module.exports = function (Twig) {
             next: Twig.expression.type.parameter.start,
             validate(match) {
                 // Make sure this function is not a reserved word
-                return match[1] && (Twig.indexOf(Twig.expression.reservedWords, match[1]) < 0);
+                return match[1] && (Twig.expression.reservedWords.indexOf(match[1]) < 0);
             },
             transform() {
                 return '(';
@@ -838,7 +838,7 @@ module.exports = function (Twig) {
             ]),
             compile: Twig.expression.fn.compile.push,
             validate(match) {
-                return (Twig.indexOf(Twig.expression.reservedWords, match[0]) < 0);
+                return (Twig.expression.reservedWords.indexOf(match[0]) < 0);
             },
             parse(token, stack, context) {
                 const state = this;
@@ -1138,7 +1138,7 @@ module.exports = function (Twig) {
             Twig.log.trace('Twig.expression.tokenize',
                 'Matched a ', type, ' regular expression of ', match);
 
-            if (next && Twig.indexOf(next, type) < 0) {
+            if (next && next.indexOf(type) < 0) {
                 invalidMatches.push(
                     type + ' cannot follow a ' + tokens[tokens.length - 1].type +
                            ' at template:' + expOffset + ' near \'' + match[0].substring(0, 20) +

--- a/src/twig.filters.js
+++ b/src/twig.filters.js
@@ -130,7 +130,7 @@ module.exports = function (Twig) {
             const keyset = value._keys || Object.keys(value);
             const output = [];
 
-            Twig.forEach(keyset, key => {
+            keyset.forEach(key => {
                 if (key === '_keys') {
                     return;
                 } // Ignore the _keys property
@@ -152,7 +152,7 @@ module.exports = function (Twig) {
                     const result = [];
                     const keyset = obj._keys || Object.keys(obj);
 
-                    Twig.forEach(keyset, key => {
+                    keyset.forEach(key => {
                         if (!Object.prototype.hasOwnProperty.call(obj, key)) {
                             return;
                         }
@@ -194,7 +194,7 @@ module.exports = function (Twig) {
                 output = value;
             } else {
                 keyset = value._keys || Object.keys(value);
-                Twig.forEach(keyset, key => {
+                keyset.forEach(key => {
                     if (key === '_keys') {
                         return;
                     } // Ignore the _keys property
@@ -231,7 +231,7 @@ module.exports = function (Twig) {
             if ((typeof value === 'object') && (is('Array', value))) {
                 const output = [];
 
-                Twig.forEach(value, v => {
+                value.forEach(v => {
                     output.push(Twig.filters.json_encode(v));
                 });
 
@@ -246,7 +246,7 @@ module.exports = function (Twig) {
                 const keyset = value._keys || Object.keys(value);
                 const output = [];
 
-                Twig.forEach(keyset, key => {
+                keyset.forEach(key => {
                     output.push(JSON.stringify(key) + ':' + Twig.filters.json_encode(value[key]));
                 });
 
@@ -262,7 +262,7 @@ module.exports = function (Twig) {
 
             // Check to see if all the objects being merged are arrays
             if (is('Array', value)) {
-                Twig.forEach(params, param => {
+                params.forEach(param => {
                     if (!is('Array', param)) {
                         obj = { };
                     }
@@ -277,7 +277,7 @@ module.exports = function (Twig) {
             }
 
             if (is('Array', value)) {
-                Twig.forEach(value, val => {
+                value.forEach(val => {
                     if (obj._keys) {
                         obj._keys.push(arrIndex);
                     }
@@ -287,7 +287,7 @@ module.exports = function (Twig) {
                 });
             } else {
                 keyset = value._keys || Object.keys(value);
-                Twig.forEach(keyset, key => {
+                keyset.forEach(key => {
                     obj[key] = value[key];
                     obj._keys.push(key);
 
@@ -306,9 +306,9 @@ module.exports = function (Twig) {
             }
 
             // Mixin the merge arrays
-            Twig.forEach(params, param => {
+            params.forEach(param => {
                 if (is('Array', param)) {
-                    Twig.forEach(param, val => {
+                    param.forEach(val => {
                         if (obj._keys) {
                             obj._keys.push(arrIndex);
                         }
@@ -318,7 +318,7 @@ module.exports = function (Twig) {
                     });
                 } else {
                     keyset = param._keys || Object.keys(param);
-                    Twig.forEach(keyset, key => {
+                    keyset.forEach(key => {
                         if (!obj[key]) {
                             obj._keys.push(key);
                         }

--- a/src/twig.functions.js
+++ b/src/twig.functions.js
@@ -135,7 +135,7 @@ module.exports = function (Twig) {
                 argsCopy.push(state.context);
             }
 
-            Twig.forEach(argsCopy, variable => {
+            argsCopy.forEach(variable => {
                 dumpVar(variable);
             });
 


### PR DESCRIPTION
The functions `Twig.indexOf` and `Twig.forEach` serve as polyfills for
`Array.prototype.indexOf` and `Array.prototype.forEach` respectively in
very old browsers such as IE8.

Modern browsers do not require these polyfills and neither does
Internet Explorer, because Internet Explorer has support for all Array
methods since IE9.