### PR TITLE
Remove redundant Babel plugin from package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,6 @@
   },
   "devDependencies": {
     "@babel/core": "^7.4.5",
-    "@babel/plugin-transform-modules-commonjs": "^7.4.4",
     "@babel/plugin-transform-runtime": "^7.4.4",
     "@babel/preset-env": "^7.4.5",
     "babel-loader": "^8.0.6",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -18,9 +18,11 @@ module.exports = {
                 use: {
                     loader: 'babel-loader',
                     options: {
-                        presets: ['@babel/preset-env'],
+                        presets: [
+                            '@babel/preset-env',
+                            {modules: false}
+                        ],
                         plugins: [
-                            '@babel/plugin-transform-modules-commonjs',
                             '@babel/plugin-transform-runtime'
                         ]
                     }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -20,7 +20,6 @@ module.exports = {
                     options: {
                         presets: ['@babel/preset-env'],
                         plugins: [
-                            '@babel/plugin-transform-modules-commonjs',
                             '@babel/plugin-transform-runtime'
                         ]
                     }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -18,11 +18,9 @@ module.exports = {
                 use: {
                     loader: 'babel-loader',
                     options: {
-                        presets: [
-                            '@babel/preset-env',
-                            {modules: 'commonjs'}
-                        ],
+                        presets: ['@babel/preset-env'],
                         plugins: [
+                            '@babel/plugin-transform-modules-commonjs',
                             '@babel/plugin-transform-runtime'
                         ]
                     }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -20,7 +20,7 @@ module.exports = {
                     options: {
                         presets: [
                             '@babel/preset-env',
-                            {modules: false}
+                            {modules: 'commonjs'}
                         ],
                         plugins: [
                             '@babel/plugin-transform-runtime'

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -20,6 +20,7 @@ module.exports = {
                     options: {
                         presets: ['@babel/preset-env'],
                         plugins: [
+                            '@babel/plugin-transform-modules-commonjs',
                             '@babel/plugin-transform-runtime'
                         ]
                     }


### PR DESCRIPTION
`@babel/plugin-transform-modules-commonjs` is already included in
`@babel/preset-env`.