### PR TITLE
Streamline Webpack builds

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2064,16 +2064,6 @@
         "sha.js": "^2.4.8"
       }
     },
-    "cross-env": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-5.2.0.tgz",
-      "integrity": "sha512-jtdNFfFW1hB7sMhr/H6rW1Z45LFqyI431m3qU6bFXcQ3Eh7LtBuG3h74o7ohHZ3crrRkkqHlo4jYHFPcjroANg==",
-      "dev": true,
-      "requires": {
-        "cross-spawn": "^6.0.5",
-        "is-windows": "^1.0.0"
-      }
-    },
     "cross-spawn": {
       "version": "6.0.5",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",

--- a/package.json
+++ b/package.json
@@ -26,10 +26,7 @@
     "postversion": "git push origin master && git push origin master --tags",
     "pretest": "npm run build",
     "test": "mocha -r should",
-    "prebuild": "npm run build-node",
-    "build-node": "webpack",
-    "build-browser": "cross-env WEBPACK_ENV=browser webpack",
-    "build": "npm run build-browser",
+    "build": "webpack",
     "posttest": "xo src lib bin"
   },
   "dependencies": {
@@ -43,7 +40,6 @@
     "@babel/plugin-transform-runtime": "^7.4.4",
     "@babel/preset-env": "^7.4.5",
     "babel-loader": "^8.0.6",
-    "cross-env": "^5.2.0",
     "eslint-plugin-mocha": "^5.3.0",
     "mocha": "^4.1.0",
     "should": "^13.2.3",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,15 +1,28 @@
-var webpack = require('webpack');
-var TerserJsPlugin = require('terser-webpack-plugin');
+const TerserJsPlugin = require('terser-webpack-plugin');
 
-var env = process.env.WEBPACK_ENV;
-
-module.exports = {
+const serverBuild = {
     mode: 'production',
     entry: './src/twig.js',
-    target: env === 'browser' ? 'web' : 'node',
+    target: 'node',
+    node: false,
+    output: {
+        path: __dirname,
+        filename: 'twig.js',
+        library: 'Twig',
+        libraryTarget: 'umd'
+    },
+    optimization: {
+        minimize: false
+    }
+};
+
+const clientBuild = {
+    mode: 'production',
+    entry: './src/twig.js',
+    target: 'web',
     node: {
         __dirname: false,
-        __filename: false,
+        __filename: false
     },
     module: {
         rules: [
@@ -30,7 +43,7 @@ module.exports = {
     },
     output: {
         path: __dirname,
-        filename: env === 'browser' ? 'twig.min.js' : 'twig.js',
+        filename: 'twig.min.js',
         library: 'Twig',
         libraryTarget: 'umd'
     },
@@ -41,3 +54,5 @@ module.exports = {
         })]
     }
 };
+
+module.exports = [serverBuild, clientBuild];


### PR DESCRIPTION
Instead of creating the server bundle and the browser bundle in two
separate Webpack builds, both bundles will be created in a single
Webpack build by having `webpack.config.js` export an array of
configuration objects.

In addition, the server build will not require transpilation as the
minimum supported NodeJS version (i.e. NodeJS 8) supports the use of
ES6 language features as is.