### PR TITLE
Make '??'-operator return the actual array instead of array length

### DIFF
--- a/src/twig.expression.operator.js
+++ b/src/twig.expression.operator.js
@@ -167,7 +167,7 @@ module.exports = function (Twig) {
             a = stack.pop();
         }
 
-        if (operator !== 'in' && operator !== 'not in') {
+        if (operator !== 'in' && operator !== 'not in' && operator !== '??') {
             if (a && Array.isArray(a)) {
                 a = a.length;
             }

--- a/test/test.expressions.operators.js
+++ b/test/test.expressions.operators.js
@@ -73,6 +73,15 @@ describe('Twig.js Expression Operators ->', function () {
             outputT.should.equal('two');
             outputF.should.equal('two');
         });
+
+        it('should support the null-coalescing operator for true conditions on objects or arrays', function () {
+            const testTemplate = twig({data: '{% set b = a ?? "nope" %}{% for item in b %}{{item}}{% endfor %}'});
+            const outputArr = testTemplate.render({a: [1,2]});
+            const outputObj = testTemplate.render({a: {b:3, c:4}});
+
+            outputArr.should.equal('12');
+            outputObj.should.equal('34');
+        });
     });
 
     describe('b-and ->', function () {

--- a/test/test.expressions.operators.js
+++ b/test/test.expressions.operators.js
@@ -75,12 +75,14 @@ describe('Twig.js Expression Operators ->', function () {
         });
 
         it('should support the null-coalescing operator for true conditions on objects or arrays', function () {
-            const testTemplate = twig({data: '{% set b = a ?? "nope" %}{% for item in b %}{{item}}{% endfor %}'});
+            const testTemplate = twig({data: '{% set b = a ?? "nope" %}{{ b | join("") }}'});
             const outputArr = testTemplate.render({a: [1,2]});
             const outputObj = testTemplate.render({a: {b:3, c:4}});
+            const outputNull = testTemplate.render();
 
             outputArr.should.equal('12');
             outputObj.should.equal('34');
+            outputNull.should.equal('nope');
         });
     });
 


### PR DESCRIPTION
The '??'-operator is very handy for setting default values. Like for example:

`{% set list = list ?? [] %}`

This works in PHP Twig. And it should of course work in twig.js too :)