### PR TITLE
Fix 'starts with' and 'ends with' expressions

### DIFF
--- a/src/twig.expression.operator.js
+++ b/src/twig.expression.operator.js
@@ -346,11 +346,11 @@ module.exports = function (Twig) {
                 break;
 
             case 'starts with':
-                stack.push(a.indexOf(b) === 0);
+                stack.push(typeof a === 'string' && a.indexOf(b) === 0);
                 break;
 
             case 'ends with':
-                stack.push(a.indexOf(b, a.length - b.length) !== -1);
+                stack.push(typeof a === 'string' && a.indexOf(b, a.length - b.length) !== -1);
                 break;
 
             case '..':

--- a/test/test.expressions.js
+++ b/test/test.expressions.js
@@ -305,12 +305,14 @@ describe('Twig.js Expressions ->', function () {
             const testTemplate = twig({data: '{{ a starts with "f" }}'});
             testTemplate.render({a: 'foo'}).should.equal('true');
             testTemplate.render({a: 'bar'}).should.equal('false');
+            testTemplate.render({}).should.equal('false');
         });
 
         it('should support ends with', function () {
             const testTemplate = twig({data: '{{ a ends with "o" }}'});
             testTemplate.render({a: 'foo'}).should.equal('true');
             testTemplate.render({a: 'bar'}).should.equal('false');
+            testTemplate.render({}).should.equal('false');
         });
 
         it('should correctly cast arrays', function () {


### PR DESCRIPTION
Fixes #660

Makes `starts with` and `ends with` expressions to not throw an error with non-string values.

Changes proposed in this pull request:

- Add a check for `starts with` and `ends with` expressions to check if it’s tested against a string.
- Add a test case where using `starts with` and `ends with` with an undefined variable.