### PR TITLE
Reusing `empty` test in `default` filter.

### DIFF
--- a/src/twig.filters.js
+++ b/src/twig.filters.js
@@ -207,14 +207,9 @@ module.exports = function (Twig) {
 
             return output.join(joinStr);
         },
-        default(value, _default) {
-            // checking _default for empty because it's resolved as `false` in parseParams
-            if (_default === false) {
-                _default = '';
-            }
-
+        default(value, params) {
             if (Twig.tests.empty(value)) {
-                return _default;
+                return params[0] || '';
             }
 
             return value;

--- a/src/twig.filters.js
+++ b/src/twig.filters.js
@@ -207,17 +207,14 @@ module.exports = function (Twig) {
 
             return output.join(joinStr);
         },
-        default(value, params) {
-            if (params !== undefined && params.length > 1) {
-                throw new Twig.Error('default filter expects one argument');
+        default(value, _default) {
+            // checking _default for empty because it's resolved as `false` in parseParams
+            if (_default === false) {
+                _default = '';
             }
 
-            if (value === undefined || value === null || value === '') {
-                if (params === undefined) {
-                    return '';
-                }
-
-                return params[0];
+            if (Twig.tests.empty(value)) {
+                return _default;
             }
 
             return value;


### PR DESCRIPTION
Improving `default` by reusing `empty` test.
Following logic https://github.com/twigphp/Twig/blob/55704ce1d29f184374f77b9542baaba58d4d30f2/src/Extension/CoreExtension.php#L810