### PR TITLE
Export tests

### DIFF
--- a/src/twig.exports.js
+++ b/src/twig.exports.js
@@ -224,6 +224,9 @@ module.exports = function (Twig) {
     // Resolves #307
     Twig.exports.filters = Twig.filters;
 
+    // Export our tests.
+    Twig.exports.tests = Twig.tests;
+
     Twig.exports.Promise = Twig.Promise;
 
     return Twig;


### PR DESCRIPTION
Similar to #307

Use-case:
- I've found a bug in production e.g: #668
- I need to apply hotfix without forking.

I simply cannot do

```
// @see https://github.com/twigjs/twig.js/pull/668
window.Twig.filters.default = (value, _default = '') => {
    if (window.Twig.tests.empty(value)) {
        return _default;
    }

    return value;
};
```