### PR TITLE
Add npm license field

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "JS port of the Twig templating language.",
   "version": "1.14.0",
   "homepage": "https://github.com/twigjs/twig.js",
+  "license": "BSD-2-Clause",
   "licenses": [
     {
       "type": "BSD-2-Clause",


### PR DESCRIPTION
Add `license` key to /package.json (fixes npm complaining about missing license field)