### PR TITLE
Fix strict_variables issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ var Twig = require("twig"),
 // This section is optional and used to configure twig.
 app.set("twig options", {
     allow_async: true, // Allow asynchronous compiling
-    strictVariables: false
+    strict_variables: false
 });
 
 app.get('/', function(req, res){

--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ var Twig = require("twig"),
 // This section is optional and used to configure twig.
 app.set("twig options", {
     allow_async: true, // Allow asynchronous compiling
-    strict_variables: false
+    strictVariables: false
 });
 
 app.get('/', function(req, res){

--- a/src/twig.core.js
+++ b/src/twig.core.js
@@ -1239,7 +1239,7 @@ module.exports = function (Twig) {
         //            options:  {
         //                Compiler/parser options
         //
-        //                strictVariables: true/false
+        //                strict_variables: true/false
         //                    Should missing variable/keys emit an error message. If false, they default to null.
         //            }
         //     }

--- a/src/twig.exports.js
+++ b/src/twig.exports.js
@@ -19,7 +19,7 @@ module.exports = function (Twig) {
         'use strict';
         const {id} = params;
         const options = {
-            strictVariables: params.strictVariables || false,
+            strictVariables: params.strict_variables || false,
             // TODO: turn autoscape on in the next major version
             autoescape: (params.autoescape !== null && params.autoescape) || false,
             allowInlineIncludes: params.allowInlineIncludes || false,

--- a/test/test.options.js
+++ b/test/test.options.js
@@ -17,5 +17,69 @@ describe('Twig.js Optional Functionality ->', function () {
 
         output.should.equal('template with another template');
     });
-});
 
+    describe('should throw an error when strictVariables set to `true`', function () {
+        const variable = twig({
+            rethrow: true,
+            strictVariables: true,
+            data: '{{ test }}'
+        });
+
+        const object = twig({
+            rethrow: true,
+            strictVariables: true,
+            data: '{{ test.10 }}'
+        });
+
+        const array = twig({
+            rethrow: true,
+            strictVariables: true,
+            data: '{{ test[10] }}'
+        });
+
+        it('For undefined variables', function () {
+            try {
+                variable.render();
+                throw new Error('should have thrown an error.');
+            } catch (error) {
+                error.message.should.equal('Variable "test" does not exist.');
+            }
+        });
+
+        it('For empty objects', function () {
+            try {
+                object.render({test: {}});
+                throw new Error('should have thrown an error.');
+            } catch (error) {
+                error.message.should.equal('Key "10" does not exist as the object is empty.');
+            }
+        });
+
+        it('For undefined object keys', function () {
+            try {
+                object.render({test: {1: 'value', 2: 'value', 3: 'value'}});
+                throw new Error('should have thrown an error.');
+            } catch (error) {
+                error.message.should.equal('Key "10" for object with keys "1, 2, 3" does not exist.');
+            }
+        });
+
+        it('For empty arrays', function () {
+            try {
+                array.render({test: []});
+                throw new Error('should have thrown an error.');
+            } catch (error) {
+                error.message.should.equal('Key "10" does not exist as the array is empty.');
+            }
+        });
+
+        it('For undefined array keys', function () {
+            try {
+                array.render({test: [1, 2, 3]});
+                throw new Error('should have thrown an error.');
+            } catch (error) {
+                error.message.should.equal('Key "10" for array with keys "0, 1, 2" does not exist.');
+            }
+        });
+    });
+});

--- a/test/test.options.js
+++ b/test/test.options.js
@@ -18,22 +18,22 @@ describe('Twig.js Optional Functionality ->', function () {
         output.should.equal('template with another template');
     });
 
-    describe('should throw an error when strictVariables set to `true`', function () {
+    describe('should throw an error when `strict_variables` set to `true`', function () {
         const variable = twig({
             rethrow: true,
-            strictVariables: true,
+            strict_variables: true,
             data: '{{ test }}'
         });
 
         const object = twig({
             rethrow: true,
-            strictVariables: true,
+            strict_variables: true,
             data: '{{ test.10 }}'
         });
 
         const array = twig({
             rethrow: true,
-            strictVariables: true,
+            strict_variables: true,
             data: '{{ test[10] }}'
         });
 


### PR DESCRIPTION
Makes it to match twigfeddle errors output

Example of new errors:
- `Variable "foo" does not exist.`
- `Key "key" for object with keys "a, b, c" does not exist.`
- `Key "key" does not exist as the object is empty.`
- `Key "10" for array with keys "0, 1, 2" does not exist.`
- `Key "10" does not exist as the array is empty.`

Live example: https://twigfiddle.com/yfnyxt
*Tip: you need to switch main template to see different output*

Closes #629