### PR TITLE
Add support for 'deprecated' tag

### DIFF
--- a/src/twig.logic.js
+++ b/src/twig.logic.js
@@ -41,7 +41,8 @@ module.exports = function (Twig) {
         embed: 'Twig.logic.type.embed',
         endembed: 'Twig.logic.type.endembed',
         with: 'Twig.logic.type.with',
-        endwith: 'Twig.logic.type.endwith'
+        endwith: 'Twig.logic.type.endwith',
+        deprecated: 'Twig.logic.type.deprecated'
     };
 
     // Regular expressions for handling logic tokens.
@@ -1272,6 +1273,25 @@ module.exports = function (Twig) {
             regex: /^endwith$/,
             next: [],
             open: false
+        },
+        {
+            /**
+             * Deprecated type logic tokens.
+             *
+             *  Format: {% deprecated 'Description' %}
+             */
+            type: Twig.logic.type.deprecated,
+            regex: /^deprecated\s+(.+)$/,
+            next: [],
+            open: true,
+            compile(token) {
+                console.warn('Deprecation notice: ' + token.match[1]);
+
+                return token;
+            },
+            parse() {
+                return {};
+            }
         }
 
     ];

--- a/test/test.tags.js
+++ b/test/test.tags.js
@@ -1,4 +1,5 @@
 const Twig = require('../twig').factory();
+const sinon = require('sinon');
 
 const {twig} = Twig;
 
@@ -52,5 +53,15 @@ describe('Twig.js Tags ->', function () {
         }).render().should.equal(
             '&lt;strong&gt;twig.js&lt;/strong&gt;'
         );
+    });
+
+    it('should support deprecated tag and show a console warn message', function () {
+        let consoleSpy = sinon.spy(console, 'warn');
+
+        twig({
+            data: '{% deprecated \'`foo` is deprecated use `bar`\' %}'
+        }).render();
+
+        consoleSpy.should.be.calledWith('Deprecation notice: \'`foo` is deprecated use `bar`\'');
     });
 });


### PR DESCRIPTION
Compiling the 'deprecated' tag will result in a warning message in the console.

Note: The 'deprecated' tag was added PHP Twig 2.6, see: https://twig.symfony.com/doc/2.x/tags/deprecated.html. 