### PR TITLE
fix autoescape for empty includes

### DIFF
--- a/src/twig.core.js
+++ b/src/twig.core.js
@@ -709,7 +709,12 @@ module.exports = function (Twig) {
             return '';
         }
 
-        return new Twig.Markup(escapedOutput.join(''), true);
+        const joinedOutput = escapedOutput.join('')
+        if (joinedOutput.length === 0) {
+            return '';
+        }
+
+        return new Twig.Markup(joinedOutput, true);
     };
 
     // Namespace for template storage and retrieval

--- a/src/twig.core.js
+++ b/src/twig.core.js
@@ -709,7 +709,7 @@ module.exports = function (Twig) {
             return '';
         }
 
-        const joinedOutput = escapedOutput.join('')
+        const joinedOutput = escapedOutput.join('');
         if (joinedOutput.length === 0) {
             return '';
         }

--- a/test/test.core.js
+++ b/test/test.core.js
@@ -441,6 +441,15 @@ describe('Twig.js Core ->', function () {
             }).should.equal('<p>&lt;test&gt;&amp;&lt;/test&gt;</p>');
         });
 
+        it('should autoescape handle empty include', function () {
+            twig({id: 'included-return', data: ''});
+            twig({
+                allowInlineIncludes: true,
+                autoescape: true,
+                data: '{% include "included-return" %}'
+            }).render().should.equal('');
+        })
+
         it('should use a correct context in the extended template', function () {
             twig({id: 'parent', data: '{% block body %}{{ value }}{% endblock body %}'});
             twig({


### PR DESCRIPTION
See test case, in the current release, it renders `[object Object]`