### PR TITLE
raw filter on the empty string

### DIFF
--- a/src/twig.core.js
+++ b/src/twig.core.js
@@ -1443,7 +1443,7 @@ module.exports = function (Twig) {
      */
 
     Twig.Markup = function (content, strategy) {
-        if (typeof content !== 'string' || content.length === 0) {
+        if (typeof content !== 'string') {
             return content;
         }
 

--- a/src/twig.filters.js
+++ b/src/twig.filters.js
@@ -745,7 +745,7 @@ module.exports = function (Twig) {
             return value[value.length - 1];
         },
         raw(value) {
-            return new Twig.Markup(value);
+            return new Twig.Markup(value || '');
         },
         batch(items, params) {
             let size = params.shift();

--- a/test/test.filters.js
+++ b/test/test.filters.js
@@ -778,6 +778,13 @@ describe('Twig.js Filters ->', function () {
                 value: '<test>&</test>'
             }).should.equal('<test>&</test>');
         });
+
+        it('should output an empty string', function () {
+            const template = twig({data: '{{ value|raw }}'});
+            template.render({value: ''}).should.equal('');
+            template.render({}).should.equal('');
+        });
+
     });
 
     describe('round ->', function () {


### PR DESCRIPTION
The raw filter return a new Markup(content) which may itself return content

 if content is the empty string. The resulting output was `[Object]` instead of the expected empty string.