### PR TITLE
Make "js" escaped strings embeddable in JSON

### DIFF
--- a/src/twig.filters.js
+++ b/src/twig.filters.js
@@ -431,10 +431,24 @@ module.exports = function (Twig) {
                     if (rawValue[i].match(/^[a-zA-Z0-9,._]$/)) {
                         result += rawValue[i];
                     } else {
+                        const char = rawValue.charAt(i);
                         const charCode = rawValue.charCodeAt(i);
 
-                        if (charCode < 0x80) {
-                            result += '\\x' + charCode.toString(16).toUpperCase();
+                        // A few characters have short escape sequences in JSON and JavaScript.
+                        // Escape sequences supported only by JavaScript, not JSON, are ommitted.
+                        // \" is also supported but omitted, because the resulting string is not HTML safe.
+                        const shortMap = {
+                            '\\': '\\\\',
+                            '/': '\\/',
+                            '\u0008': '\\b',
+                            '\u000C': '\\f',
+                            '\u000A': '\\n',
+                            '\u000D': '\\r',
+                            '\u0009': '\\t'
+                        };
+
+                        if (shortMap[char]) {
+                            result += shortMap[char];
                         } else {
                             result += Twig.lib.sprintf('\\u%04s', charCode.toString(16).toUpperCase());
                         }

--- a/test/test.core.js
+++ b/test/test.core.js
@@ -408,7 +408,7 @@ describe('Twig.js Core ->', function () {
                 data: '{{ value }}'
             }).render({
                 value: '<test>&</test>'
-            }).should.equal('\\x3Ctest\\x3E\\x26\\x3C\\x2Ftest\\x3E');
+            }).should.equal('\\u003Ctest\\u003E\\u0026\\u003C\\/test\\u003E');
         });
 
         it('should not auto escape html_attr within the html strategy', function () {
@@ -509,4 +509,3 @@ describe('Twig.js Core ->', function () {
         });
     });
 });
-

--- a/test/test.filters.js
+++ b/test/test.filters.js
@@ -453,7 +453,7 @@ describe('Twig.js Filters ->', function () {
             testTemplate.render(data).should.equal('html: &lt;foo&gt; \\&amp;&quot;&#039;.,-_?/Ķä€台北[]{}\t\r\n\b\u0080');
 
             testTemplate = twig({data: 'js: {{ foo|escape("js") }}'});
-            testTemplate.render(data).should.equal('js: \\x3Cfoo\\x3E\\x20\\x5C\\x26\\x22\\x27.,\\x2D_\\x3F\\x2F\\u0136\\u00E4\\u20AC\\u53F0\\u5317\\x5B\\x5D\\x7B\\x7D\\x9\\xD\\xA\\x8\\u0080');
+            testTemplate.render(data).should.equal('js: \\u003Cfoo\\u003E\\u0020\\\\\\u0026\\u0022\\u0027.,\\u002D_\\u003F\\/\\u0136\\u00E4\\u20AC\\u53F0\\u5317\\u005B\\u005D\\u007B\\u007D\\t\\r\\n\\b\\u0080');
 
             testTemplate = twig({data: 'css: {{ foo|escape("css") }}'});
             testTemplate.render(data).should.equal('css: \\3C foo\\3E \\20 \\5C \\26 \\22 \\27 \\2E \\2C \\2D \\5F \\3F \\2F \\136 \\E4 \\20AC \\53F0 \\5317 \\5B \\5D \\7B \\7D \\9 \\D \\A \\8 \\80 ');
@@ -471,7 +471,7 @@ describe('Twig.js Filters ->', function () {
                 data: '{{ value|escape("js") }}'
             }).render({
                 value: '<test>&</test>'
-            }).should.equal('\\x3Ctest\\x3E\\x26\\x3C\\x2Ftest\\x3E');
+            }).should.equal('\\u003Ctest\\u003E\\u0026\\u003C\\/test\\u003E');
         });
 
         it('should not escape twice if autoescape is not html', function () {
@@ -480,7 +480,7 @@ describe('Twig.js Filters ->', function () {
                 data: '{{ value|escape("js") }}'
             }).render({
                 value: '<test>&</test>'
-            }).should.equal('\\x3Ctest\\x3E\\x26\\x3C\\x2Ftest\\x3E');
+            }).should.equal('\\u003Ctest\\u003E\\u0026\\u003C\\/test\\u003E');
         });
 
         it('should escape twice if escape strategy is different from autoescape option', function () {
@@ -489,7 +489,7 @@ describe('Twig.js Filters ->', function () {
                 data: '{{ value|escape("js") }}\n{{ value|escape }}'
             }).render({
                 value: '<test>&</test>'
-            }).should.equal('\\5C x3Ctest\\5C x3E\\5C x26\\5C x3C\\5C x2Ftest\\5C x3E\n\\26 lt\\3B test\\26 gt\\3B \\26 amp\\3B \\26 lt\\3B \\2F test\\26 gt\\3B ');
+            }).should.equal('\\5C u003Ctest\\5C u003E\\5C u0026\\5C u003C\\5C \\2F test\\5C u003E\n\\26 lt\\3B test\\26 gt\\3B \\26 amp\\3B \\26 lt\\3B \\2F test\\26 gt\\3B ');
         });
     });
 


### PR DESCRIPTION
The ["js" escape strategy of Twig PHP](https://github.com/twigphp/Twig/blob/6384ba6c3ca7695ef0aec93bdf3b55c9bb18b5de/src/Extension/EscaperExtension.php#L247-L295) produces a JSON compatible escaping.
This is useful as it allows embedding JS escaped strings in JSON script.

For example, this can be used to templates JSON-LD scripts:

```html
<script type="application/ld+json">
{
  "@context": "http://schema.org/",
  "@type": "Person",
  "name": "{{ name }}",
}
</script>
```

Unfortunately, the twig.js implementation doesn't produce JSON compatible escaping.

For example:

```js
const { twig } = require('twig');
const compiledTemplate = twig({ autoescape: 'js', data: '{{ foo }}' });
compiledTemplate.render({ foo: '<foo>' });

// > \x3Cfoo\x3E
```

`\x3Cfoo\x3E` is not [valid JSON](https://tools.ietf.org/html/rfc7159#section-7) and can't be parsed by some JSON parsers.

With the same template/data, Twig PHP returns `\u003Cfoo\u003E`:

```php
<?php
$twig = new \Twig\Environment(new \Twig\Loader\ArrayLoader(), ['autoescape' => 'js']);
$twig->createTemplate('{{ foo }}')->render(['foo' => '<foo>']);

// > \u003Cfoo\u003E
```

In TwigPHP, The "js" escape strategy is defined there: https://github.com/twigphp/Twig/blob/6384ba6c3ca7695ef0aec93bdf3b55c9bb18b5de/src/Extension/EscaperExtension.php#L247-L295

Note: This PR replaces JSON-incompatible hexadecimal escape sequences (\x..) with JSON-compatible unicode escape sequences (\u00..).
It also prevents the escaping of some chars that are not escaped by TwigPHP.
This fixes specific use cases, but it doesn't make the escaping fully compatible with TwigPHP's.

I noticed that [`twing`](https://github.com/NightlyCommit/twing/blob/cb934c305bf68e8e507918275d477a1f7a45b387/src/lib/extension/core/filters/escape.ts#L52-L100) outputs the same string as TwigPHP.
Maybe you can help us, here, @ericmorand?