### PR TITLE
Fix `last` filter for numbers

### DIFF
--- a/src/twig.filters.js
+++ b/src/twig.filters.js
@@ -741,6 +741,10 @@ module.exports = function (Twig) {
                 return value[keys[keys.length - 1]];
             }
 
+            if (Twig.lib.is('Number', value)) {
+                return value.toString().slice(-1);
+            }
+
             // String|array
             return value[value.length - 1];
         },

--- a/test/test.filters.js
+++ b/test/test.filters.js
@@ -756,6 +756,16 @@ describe('Twig.js Filters ->', function () {
             const testTemplate = twig({data: '{{ {\'m\':1, \'z\':5, \'a\':3}|sort|last }}'});
             testTemplate.render().should.equal('5');
         });
+        it('should return the last digit of numbers', function () {
+            const singleDigitTemplate = twig({data: '{{ 1|last }}'});
+            singleDigitTemplate.render().should.equal('1');
+
+            const multiDigitTemplate = twig({data: '{{ 130|last }}'});
+            multiDigitTemplate.render().should.equal('0');
+
+            const floatTemplate = twig({data: '{{ 142.7|last }}'});
+            floatTemplate.render().should.equal('7');
+        });
     });
 
     describe('raw ->', function () {


### PR DESCRIPTION
While not unit tested, TwigPHP's `last` filter returns the last digit of
a number, not `""`.

With TwigPHP:

```twig
{{ 14|last }} # returns '4'
```

Currently, with twig.js

```twig
{{ 14|last }} # returns ''
```

See: https://twigfiddle.com/e28i2l