### PR TITLE
making sure that ternary expression does not change context

### DIFF
--- a/src/twig.exports.js
+++ b/src/twig.exports.js
@@ -227,6 +227,9 @@ module.exports = function (Twig) {
     // Export our tests.
     Twig.exports.tests = Twig.tests;
 
+    // Export our functions.
+    Twig.exports.functions = Twig.functions;
+
     Twig.exports.Promise = Twig.Promise;
 
     return Twig;

--- a/src/twig.expression.operator.js
+++ b/src/twig.expression.operator.js
@@ -172,7 +172,7 @@ module.exports = function (Twig) {
                 a = a.length;
             }
 
-            if (b && Array.isArray(b)) {
+            if (operator !== '?' && (b && Array.isArray(b))) {
                 b = b.length;
             }
         }

--- a/test/test.regression.js
+++ b/test/test.regression.js
@@ -29,4 +29,11 @@ describe('Twig.js Regression Tests ->', function () {
         twig({data: '{% raw %}\n"\n{% endraw %}'}).render().should.equal('"');
         twig({data: '{% raw %}\n\'\n{% endraw %}'}).render().should.equal('\'');
     });
+
+    it('#737 ternary expression should not override context', function () {
+        const str = `{% set classes = ['a', 'b'] %}{% set classes = classes ? classes|merge(['c']) : '' %}{{ dump(classes) }}`;
+        const expected = Twig.functions.dump(['a', 'b', 'c']);
+        const testTemplate = twig({data: str});
+        testTemplate.render().should.equal(expected);
+    });
 });


### PR DESCRIPTION
fixing #737 making sure that ternary expression does not change context + exporting functions for test purposes