### PR TITLE
Specify MimeType to always use for ajax templates

### DIFF
--- a/src/twig.loader.ajax.js
+++ b/src/twig.loader.ajax.js
@@ -40,6 +40,7 @@ module.exports = function (Twig) {
         };
 
         xmlhttp.open('GET', location, Boolean(params.async));
+        xmlhttp.overrideMimeType('text/plain');
         xmlhttp.send();
 
         if (params.async) {


### PR DESCRIPTION
For twig.js to be used in the browser, it requires the user to know that they either must name their templates as an ending that browsers recognized (e.g. `txt` or `html`) or to manually register a mime-type to the `.twig` extension. Otherwise, when fetching a template, a browser will attempt to parse it using `text/xml` which can cause issues depending on strictness (e.g. #741).

This PR changes it so that twig.js always specifies that templates received via XMLHttpRequest are `text/plain` and to be treated as such.