### PR TITLE
Added token count validation

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -4,7 +4,6 @@ test
 test-ext
 docs
 qtest
-src
 .hg
 .git
 .gitignore

--- a/src/twig.async.js
+++ b/src/twig.async.js
@@ -348,7 +348,7 @@ module.exports = function (Twig) {
     * Each item in the array will be called sequentially.
     */
     Twig.async.forEach = function (arr, callback) {
-        const len = arr.length;
+        const len = arr ? arr.length : 0;
         let index = 0;
 
         function next() {


### PR DESCRIPTION
Sometimes when a Twig file has a syntax error, for some reason the template object has no tokens to render, but it's sent to render anyway, causing an error. This should fix this error