### PR TITLE
Add support for template arrays when using extends

### DIFF
--- a/src/twig.logic.js
+++ b/src/twig.logic.js
@@ -710,26 +710,21 @@ module.exports = function (Twig) {
                 return Twig.expression.parseAsync.call(state, token.stack, context)
                     .then(fileName => {
                         if (Array.isArray(fileName)) {
-                            const result = fileName.reduce((acc, file) => {
+                            const result = fileName.reverse().reduce((acc, file) => {
                                 try {
                                     return {
                                         render: state.template.importFile(file),
-                                        fileName: file,
-                                        lastError: null
+                                        fileName: file
                                     };
+                                    /* eslint-disable-next-line no-unused-vars */
                                 } catch (error) {
-                                    return {
-                                        render: null,
-                                        fileName: null,
-                                        lastError: error
-                                    };
+                                    return acc;
                                 }
                             }, {
                                 render: null,
-                                fileName: null,
-                                lastError: null
+                                fileName: null
                             });
-                            if (result.lastError === null && result.fileName) {
+                            if (result.fileName !== null) {
                                 state.template.parentTemplate = result.fileName;
                             }
                         } else {

--- a/src/twig.logic.js
+++ b/src/twig.logic.js
@@ -709,7 +709,32 @@ module.exports = function (Twig) {
 
                 return Twig.expression.parseAsync.call(state, token.stack, context)
                     .then(fileName => {
-                        state.template.parentTemplate = fileName;
+                        if (Array.isArray(fileName)) {
+                            const result = fileName.reduce((acc, file) => {
+                                try {
+                                    return {
+                                        render: state.template.importFile(file),
+                                        fileName: file,
+                                        lastError: null
+                                    };
+                                } catch (error) {
+                                    return {
+                                        render: null,
+                                        fileName: null,
+                                        lastError: error
+                                    };
+                                }
+                            }, {
+                                render: null,
+                                fileName: null,
+                                lastError: null
+                            });
+                            if (result.lastError === null && result.fileName) {
+                                state.template.parentTemplate = result.fileName;
+                            }
+                        } else {
+                            state.template.parentTemplate = fileName;
+                        }
 
                         return {
                             chain,

--- a/test/templates/extendee-array.twig
+++ b/test/templates/extendee-array.twig
@@ -1,0 +1,1 @@
+Hello, world!

--- a/test/templates/extender-array-none-exist.twig
+++ b/test/templates/extender-array-none-exist.twig
@@ -1,0 +1,2 @@
+{% extends ['notfound.twig', 'definitelynotfound.twig'] %}
+Nothing to see here

--- a/test/templates/extender-array-second-exists.twig
+++ b/test/templates/extender-array-second-exists.twig
@@ -1,0 +1,1 @@
+{% extends ['notfound.twig', 'extendee-array.twig'] %}

--- a/test/templates/extender-array.twig
+++ b/test/templates/extender-array.twig
@@ -1,0 +1,1 @@
+{% extends ['extendee-array.twig'] %}

--- a/test/test.fs.js
+++ b/test/test.fs.js
@@ -163,3 +163,34 @@ describe('Twig.js Include ->', function () {
     });
 });
 
+describe('Twig.js Extends ->', function () {
+    it('should load the first template when passed an array', function () {
+        const template = twig({
+            path: 'test/templates/extender-array.twig',
+            async: false
+        });
+
+        const output = template.render();
+        output.trim().should.equal('Hello, world!');
+    });
+
+    it('should load the second template when passed an array where the first value does not exist', function () {
+        const template = twig({
+            path: 'test/templates/extender-array-second-exists.twig',
+            async: false
+        });
+
+        const output = template.render();
+        output.trim().should.equal('Hello, world!');
+    });
+
+    it('should silently fail when passed an array with no templates that exist', function () {
+        const template = twig({
+            path: 'test/templates/extender-array-none-exist.twig',
+            async: false
+        });
+
+        const output = template.render();
+        output.trim().should.equal('Nothing to see here');
+    });
+});


### PR DESCRIPTION
This currently doesn't work:

```
{% extends ['one.twig', 'two.twig'] %}
```

See https://twig.symfony.com/doc/2.x/tags/extends.html#dynamic-inheritance under "You can also provide a list of templates that are checked for existence"