### PR TITLE
Update browser usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ A bower package is available from [philsbury](https://github.com/philsbury/twigj
 Include twig.js or twig.min.js in your page, then:
 
 ```js
-var template = twig({
+var template = Twig.twig({
     data: 'The {{ baked_good }} is a lie.'
 });
 


### PR DESCRIPTION
After trying to use Twig on the browser with `twig({...})` and getting ` ReferenceError: twig is not defined` I realized I needed to do `Twig.twig({...})` instead. 

If this not always the case let me know so I can improve the documentation in this regard. 

It can be seen happening here: https://jsbench.me/6gkgwawsrs/1. Notice the import from unpkg.