### PR TITLE
Imported function PATHS.strip_slash() missing

### DIFF
--- a/bin/twigjs
+++ b/bin/twigjs
@@ -24,7 +24,7 @@ while (args.length > 0) {
             return;
         case "--output":
         case "-o":
-            options.output = PATHS.strip_slash(args.shift());
+            options.output = PATHS.stripSlash(args.shift());
             break;
         case "--pattern":
         case "-p":


### PR DESCRIPTION
Exported function `strip_slash()` renamed to `stripSlash()` causing twigjs compilation command fail.