### PR TITLE
feat: context in filters

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .idea/
 node_modules/
+.vscode/
 twig.js
 twig.min.js
 twig.min.js.map

--- a/src/twig.expression.js
+++ b/src/twig.expression.js
@@ -768,7 +768,7 @@ module.exports = function (Twig) {
 
                 return parseParams(state, token.params, context)
                     .then(params => {
-                        return Twig.filter.call(state, token.value, input, params);
+                        return Twig.filter.call(state, token.value, input, params, context);
                     })
                     .then(value => {
                         stack.push(value);

--- a/src/twig.filters.js
+++ b/src/twig.filters.js
@@ -823,14 +823,14 @@ module.exports = function (Twig) {
         }
     };
 
-    Twig.filter = function (filter, value, params) {
+    Twig.filter = function (filter, value, params, context) {
         const state = this;
 
         if (!Twig.filters[filter]) {
             throw new Twig.Error('Unable to find filter ' + filter);
         }
 
-        return Twig.filters[filter].call(state, value, params);
+        return Twig.filters[filter].call(state, value, params, context);
     };
 
     Twig.filter.extend = function (filter, definition) {

--- a/test/test.extends.js
+++ b/test/test.extends.js
@@ -1,156 +1,173 @@
+const sinon = require('sinon')
 const Twig = require('../twig').factory();
 
 const {twig} = Twig;
 
 describe('Twig.js Extensions ->', function () {
-    it('should be able to extend a meta-type tag', function () {
-        const flags = {};
+    describe('Tags ->', function () {
+        it('should be able to extend a meta-type tag', function () {
+            const flags = {};
 
-        Twig.extend(Twig => {
-            Twig.exports.extendTag({
-                type: 'flag',
-                regex: /^flag\s+(.+)$/,
-                next: [],
-                open: true,
-                compile(token) {
-                    const expression = token.match[1];
+            Twig.extend(Twig => {
+                Twig.exports.extendTag({
+                    type: 'flag',
+                    regex: /^flag\s+(.+)$/,
+                    next: [],
+                    open: true,
+                    compile(token) {
+                        const expression = token.match[1];
 
-                    // Compile the expression.
-                    token.stack = Reflect.apply(Twig.expression.compile, this, [{
-                        type: Twig.expression.type.expression,
-                        value: expression
-                    }]).stack;
+                        // Compile the expression.
+                        token.stack = Reflect.apply(Twig.expression.compile, this, [{
+                            type: Twig.expression.type.expression,
+                            value: expression
+                        }]).stack;
 
-                    delete token.match;
-                    return token;
-                },
-                parse(token, context, _) {
-                    const name = Reflect.apply(Twig.expression.parse, this, [token.stack, context]);
-                    const output = '';
+                        delete token.match;
+                        return token;
+                    },
+                    parse(token, context, _) {
+                        const name = Reflect.apply(Twig.expression.parse, this, [token.stack, context]);
+                        const output = '';
 
-                    flags[name] = true;
+                        flags[name] = true;
 
-                    return {
-                        chain: false,
-                        output
-                    };
-                }
-            });
-        });
-
-        twig({data: '{% flag \'enabled\' %}'}).render();
-        flags.enabled.should.equal(true);
-    });
-
-    it('should be able to extend paired tags', function () {
-        // Demo data
-        const App = {
-            user: 'john',
-            users: {
-                john: {level: 'admin'},
-                tom: {level: 'user'}
-            }
-        };
-
-        Twig.extend(Twig => {
-            // Example of extending a tag type that would
-            // restrict content to the specified "level"
-            Twig.exports.extendTag({
-                type: 'auth',
-                regex: /^auth\s+(.+)$/,
-                next: ['endauth'], // Match the type of the end tag
-                open: true,
-                compile(token) {
-                    const expression = token.match[1];
-
-                    // Turn the string expression into tokens.
-                    token.stack = Reflect.apply(Twig.expression.compile, this, [{
-                        type: Twig.expression.type.expression,
-                        value: expression
-                    }]).stack;
-
-                    delete token.match;
-                    return token;
-                },
-                parse(token, context, chain) {
-                    const level = Reflect.apply(Twig.expression.parse, this, [token.stack, context]);
-                    let output = '';
-
-                    if (App.users[App.currentUser].level === level) {
-                        output = this.parse(token.output, context);
+                        return {
+                            chain: false,
+                            output
+                        };
                     }
+                });
+            });
 
-                    return {
-                        chain,
-                        output
-                    };
-                }
-            });
-            Twig.exports.extendTag({
-                type: 'endauth',
-                regex: /^endauth$/,
-                next: [],
-                open: false
-            });
+            twig({data: '{% flag \'enabled\' %}'}).render();
+            flags.enabled.should.equal(true);
         });
 
-        const template = twig({data: 'Welcome{% auth \'admin\' %} ADMIN{% endauth %}!'});
+        it('should be able to extend paired tags', function () {
+            // Demo data
+            const App = {
+                user: 'john',
+                users: {
+                    john: {level: 'admin'},
+                    tom: {level: 'user'}
+                }
+            };
 
-        App.currentUser = 'john';
-        template.render().should.equal('Welcome ADMIN!');
+            Twig.extend(Twig => {
+                // Example of extending a tag type that would
+                // restrict content to the specified "level"
+                Twig.exports.extendTag({
+                    type: 'auth',
+                    regex: /^auth\s+(.+)$/,
+                    next: ['endauth'], // Match the type of the end tag
+                    open: true,
+                    compile(token) {
+                        const expression = token.match[1];
 
-        App.currentUser = 'tom';
-        template.render().should.equal('Welcome!');
+                        // Turn the string expression into tokens.
+                        token.stack = Reflect.apply(Twig.expression.compile, this, [{
+                            type: Twig.expression.type.expression,
+                            value: expression
+                        }]).stack;
+
+                        delete token.match;
+                        return token;
+                    },
+                    parse(token, context, chain) {
+                        const level = Reflect.apply(Twig.expression.parse, this, [token.stack, context]);
+                        let output = '';
+
+                        if (App.users[App.currentUser].level === level) {
+                            output = this.parse(token.output, context);
+                        }
+
+                        return {
+                            chain,
+                            output
+                        };
+                    }
+                });
+                Twig.exports.extendTag({
+                    type: 'endauth',
+                    regex: /^endauth$/,
+                    next: [],
+                    open: false
+                });
+            });
+
+            const template = twig({data: 'Welcome{% auth \'admin\' %} ADMIN{% endauth %}!'});
+
+            App.currentUser = 'john';
+            template.render().should.equal('Welcome ADMIN!');
+
+            App.currentUser = 'tom';
+            template.render().should.equal('Welcome!');
+        });
+
+        it('should be able to extend the same tag twice, replacing it', function () {
+            let result;
+
+            Twig.extend(Twig => {
+                Twig.exports.extendTag({
+                    type: 'noop',
+                    regex: /^noop$/,
+                    next: [],
+                    open: true,
+                    parse(_) {
+                        return {
+                            chain: false,
+                            output: 'noop1'
+                        };
+                    }
+                });
+            });
+
+            result = twig({data: '{% noop %}'}).render();
+            result.should.equal('noop1');
+
+            Twig.extend(Twig => {
+                Twig.exports.extendTag({
+                    type: 'noop',
+                    regex: /^noop$/,
+                    next: [],
+                    open: true,
+                    parse(_) {
+                        return {
+                            chain: false,
+                            output: 'noop2'
+                        };
+                    }
+                });
+            });
+
+            result = twig({data: '{% noop %}'}).render();
+            result.should.equal('noop2');
+        });
+
+        it('should extend the parent context when extending', function () {
+            const template = twig({
+                path: 'test/templates/extender.twig',
+                async: false
+            });
+
+            const output = template.render();
+
+            output.trim().should.equal('ok!');
+        });
     });
 
-    it('should be able to extend the same tag twice, replacing it', function () {
-        let result;
+    describe('Filters ->', function () {
+        it('should invoke custom filters with context', function () {
+            const identityFilterStub = sinon.stub().returnsArg(0)
 
-        Twig.extend(Twig => {
-            Twig.exports.extendTag({
-                type: 'noop',
-                regex: /^noop$/,
-                next: [],
-                open: true,
-                parse(_) {
-                    return {
-                        chain: false,
-                        output: 'noop1'
-                    };
-                }
+            Twig.extend(Twig => {
+                Twig.exports.extendFilter('identity', identityFilterStub);
             });
+
+            const output = twig({data: '{{ "hello world" | identity }}'}).render({ hello: 'world' });
+            output.should.equal('hello world');
+            identityFilterStub.should.be.calledWith('hello world', false, { hello: 'world'})
         });
-
-        result = twig({data: '{% noop %}'}).render();
-        result.should.equal('noop1');
-
-        Twig.extend(Twig => {
-            Twig.exports.extendTag({
-                type: 'noop',
-                regex: /^noop$/,
-                next: [],
-                open: true,
-                parse(_) {
-                    return {
-                        chain: false,
-                        output: 'noop2'
-                    };
-                }
-            });
-        });
-
-        result = twig({data: '{% noop %}'}).render();
-        result.should.equal('noop2');
-    });
-
-    it('should extend the parent context when extending', function () {
-        const template = twig({
-            path: 'test/templates/extender.twig',
-            async: false
-        });
-
-        const output = template.render();
-
-        output.trim().should.equal('ok!');
     });
 });


### PR DESCRIPTION
Provides context to custom filters as third parameter:

```js
function filter(input, params, context) {
 // ...
}
```

This is often useful when implementing custom filters whose logic may need access to the rendering context. An easy workaround is to provide the context (or part of it) as a filter parameter, but this option doesn't require any syntax changes in the templates.