### PR TITLE
Fix #708 - Allow multiple includes of a template that embeds another …

### DIFF
--- a/src/twig.logic.js
+++ b/src/twig.logic.js
@@ -1238,7 +1238,7 @@ module.exports = function (Twig) {
                     .then(fileName => {
                         const embedOverrideTemplate = new Twig.Template({
                             data: token.output,
-                            id: state.template.id,
+                            id: `${state.template.id}-override`,
                             base: state.template.base,
                             path: state.template.path,
                             url: state.template.url,


### PR DESCRIPTION
Multiple template includes that embed other template breaks the compilation.

This PR is basically @JamesB797 's fix.

Issue: https://github.com/twigjs/twig.js/issues/708