### PR TITLE
Convert non-string values to string before replacing

### DIFF
--- a/src/twig.lib.js
+++ b/src/twig.lib.js
@@ -44,12 +44,12 @@ module.exports = function (Twig) {
     };
 
     Twig.lib.replaceAll = function (string, search, replace) {
+        // Convert type to string if needed
+        const stringToChange = typeof string === 'string' ? string : string.toString();
         // Escape possible regular expression syntax
         const searchEscaped = search.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
-
-        return string.replace(new RegExp(searchEscaped, 'g'), replace);
+        return stringToChange.replace(new RegExp(searchEscaped, 'g'), replace);
     };
-
     // Chunk an array (arr) into arrays of (size) items, returns an array of arrays, or an empty array on invalid input
     Twig.lib.chunkArray = function (arr, size) {
         const returnVal = [];


### PR DESCRIPTION
Ran into an issue where the replace filter broke with the error `string.replace is not a function` because the value was typed as a number rather than a string. This converts any non-string values to string with toString() before attempting to call the replace() method.