### PR TITLE
Add GitHub actions test workflow

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,36 @@
+name: "tests"
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  tests:
+    name: "Node v${{ matrix.node_js }}"
+
+    runs-on: "ubuntu-latest"
+
+    strategy:
+      fail-fast: true
+      matrix:
+        node_js:
+          - 10
+          - 11
+          - 12
+          - 13
+
+    steps:
+      - name: "Checkout code"
+        uses: "actions/checkout@v2"
+
+      - name: "Setup Node and npm"
+        uses: "actions/setup-node@v3"
+        with:
+          cache: "npm"
+          node-version: "${{ matrix.node_js }}"
+
+      - name: "Install Node dependencies"
+        run: "npm ci"
+
+      - name: "Run tests"
+        run: "npm run test"

--- a/src/twig.lib.js
+++ b/src/twig.lib.js
@@ -50,6 +50,7 @@ module.exports = function (Twig) {
         const searchEscaped = search.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
         return stringToChange.replace(new RegExp(searchEscaped, 'g'), replace);
     };
+
     // Chunk an array (arr) into arrays of (size) items, returns an array of arrays, or an empty array on invalid input
     Twig.lib.chunkArray = function (arr, size) {
         const returnVal = [];


### PR DESCRIPTION
This adds a workflow to run the test suite. It currently only runs on pull requests, but could be expanded if needed.

This resolves #815.