### PR TITLE
Fix multiple includes with embeds

### DIFF
--- a/src/twig.logic.js
+++ b/src/twig.logic.js
@@ -1239,7 +1239,6 @@ module.exports = function (Twig) {
                     .then(fileName => {
                         const embedOverrideTemplate = new Twig.Template({
                             data: token.output,
-                            id: state.template.id,
                             base: state.template.base,
                             path: state.template.path,
                             url: state.template.url,

--- a/test/test.embed.js
+++ b/test/test.embed.js
@@ -144,4 +144,22 @@ describe('Twig.js Embed ->', function () {
             data: '{% extends "layout.twig" %}{% block body_header %}override-body-header{% endblock %}{% block body_content %}{% embed "section.twig" %}{% block section_content %}override-section-content{% endblock %}{% endembed %}{% endblock %}'
         }).render().should.equal('<layout-header><override-body-header><section-title><override-section-content><layout-body-footer><base-footer>');
     });
+
+    it('should work when within include rendered multiple times', function () {
+        twig({
+          'data': 'embed',
+          'id': 'embed.twig',
+        });
+
+        twig({
+          'allowInlineIncludes': true,
+          'data': '{% embed "embed.twig" %}{% endembed %}',
+          'id': 'include.twig',
+        });
+
+        twig({
+          'allowInlineIncludes': true,
+          'data': '{% include "include.twig" %} {% include "include.twig" %}',
+        }).render().should.equal('embed embed');
+    });
 });


### PR DESCRIPTION
This PR supersedes #784. After creating a failing test and debugging the issue, it turns out that the `id` should have never been set on the temporary template instance, since that stored it in the registry and allowed subsequent calls to the loader to return the temporary instance instead of the correct instance set before the embed.

Fixes #708