### PR TITLE
Add support for `divisible by` test

### DIFF
--- a/docs/tests.md
+++ b/docs/tests.md
@@ -79,7 +79,7 @@
      - [empty test ->](#twigjs-tests---empty-test--)
      - [odd test ->](#twigjs-tests---odd-test--)
      - [even test ->](#twigjs-tests---even-test--)
-     - [divisibleby test ->](#twigjs-tests---divisibleby-test--)
+     - [divisible by test ->](#twigjs-tests---divisible-by-test--)
      - [defined test ->](#twigjs-tests---defined-test--)
      - [none test ->](#twigjs-tests---none-test--)
      - [sameas test ->](#twigjs-tests---sameas-test--)
@@ -3486,13 +3486,13 @@ twig({data: '{{ (1 + 4) is even }}'}).render().should.equal("false" );
 twig({data: '{{ 6 is even }}'}).render().should.equal("true" );
 ```
 
-<a name="twigjs-tests---divisibleby-test--"></a>
-## divisibleby test ->
+<a name="twigjs-tests---divisible-by-test--"></a>
+## divisible by test ->
 should determine if a number is divisible by the given number.
 
 ```js
-twig({data: '{{ 5 is divisibleby(3) }}'}).render().should.equal("false" );
-twig({data: '{{ 6 is divisibleby(3) }}'}).render().should.equal("true" );
+twig({data: '{{ 5 is divisible by(3) }}'}).render().should.equal("false" );
+twig({data: '{{ 6 is divisible by(3) }}'}).render().should.equal("true" );
 ```
 
 <a name="twigjs-tests---defined-test--"></a>

--- a/src/twig.expression.js
+++ b/src/twig.expression.js
@@ -143,7 +143,7 @@ module.exports = function (Twig) {
     Twig.expression.definitions = [
         {
             type: Twig.expression.type.test,
-            regex: /^is\s+(not)?\s*([a-zA-Z_]\w*(\s?as)?)/,
+            regex: /^is\s+(not)?\s*([a-zA-Z_]\w*(\s?(?:as|by))?)/,
             next: Twig.expression.set.operations.concat([Twig.expression.type.parameter.start]),
             compile(token, stack, output) {
                 token.filter = token.match[2];

--- a/src/twig.tests.js
+++ b/src/twig.tests.js
@@ -34,6 +34,9 @@ module.exports = function (Twig) {
         even(value) {
             return value % 2 === 0;
         },
+        'divisible by'(value, params) {
+            return value % params[0] === 0;
+        },
         divisibleby(value, params) {
             return value % params[0] === 0;
         },

--- a/src/twig.tests.js
+++ b/src/twig.tests.js
@@ -38,7 +38,8 @@ module.exports = function (Twig) {
             return value % params[0] === 0;
         },
         divisibleby(value, params) {
-            return value % params[0] === 0;
+            console.warn('`divisibleby` is deprecated use `divisible by`');
+            return Twig.tests['divisible by'](value, params);
         },
         defined(value) {
             return value !== undefined;

--- a/test/test.tests.js
+++ b/test/test.tests.js
@@ -46,6 +46,11 @@ describe('Twig.js Tests ->', function () {
 
     describe('divisibleby test ->', function () {
         it('should determine if a number is divisible by the given number', function () {
+            twig({data: '{{ 5 is divisible by(3) }}'}).render().should.equal('false');
+            twig({data: '{{ 6 is divisible by(3) }}'}).render().should.equal('true');
+        });
+
+        it('should determine if a number is divisible by the given number', function () {
             twig({data: '{{ 5 is divisibleby(3) }}'}).render().should.equal('false');
             twig({data: '{{ 6 is divisibleby(3) }}'}).render().should.equal('true');
         });

--- a/test/test.tests.js
+++ b/test/test.tests.js
@@ -44,13 +44,13 @@ describe('Twig.js Tests ->', function () {
         });
     });
 
-    describe('divisibleby test ->', function () {
+    describe('divisible by test ->', function () {
         it('should determine if a number is divisible by the given number', function () {
             twig({data: '{{ 5 is divisible by(3) }}'}).render().should.equal('false');
             twig({data: '{{ 6 is divisible by(3) }}'}).render().should.equal('true');
         });
 
-        it('should determine if a number is divisible by the given number', function () {
+        it('should support the old version without space for backwards compatibility', function () {
             twig({data: '{{ 5 is divisibleby(3) }}'}).render().should.equal('false');
             twig({data: '{{ 6 is divisibleby(3) }}'}).render().should.equal('true');
         });


### PR DESCRIPTION
This deprecates `divisibleby` and updates references in the docs.

This resolves #804.