### PR TITLE
Use v3 of `actions/checkout`

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -21,7 +21,7 @@ jobs:
 
     steps:
       - name: "Checkout code"
-        uses: "actions/checkout@v2"
+        uses: "actions/checkout@v3"
 
       - name: "Setup Node and npm"
         uses: "actions/setup-node@v3"


### PR DESCRIPTION
This fixes the deprecation notice in the actions by using NodeJS v16 instead of v12.

@RobLoach I'm going ahead and merging this since it's so minor.