### PR TITLE
Test on more node versions

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -18,6 +18,7 @@ jobs:
           - 11
           - 12
           - 13
+          - 14
 
     steps:
       - name: "Checkout code"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -21,6 +21,7 @@ jobs:
           - 14
           - 15
           - 16
+          - 17
 
     steps:
       - name: "Checkout code"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -19,6 +19,7 @@ jobs:
           - 12
           - 13
           - 14
+          - 15
 
     steps:
       - name: "Checkout code"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -20,6 +20,7 @@ jobs:
           - 13
           - 14
           - 15
+          - 16
 
     steps:
       - name: "Checkout code"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -22,6 +22,7 @@ jobs:
           - 15
           - 16
           - 17
+          - 18
 
     steps:
       - name: "Checkout code"

--- a/node/build.js
+++ b/node/build.js
@@ -1,0 +1,9 @@
+const child_process = require('child_process');
+
+child_process.spawn(
+    'webpack',
+    [],
+    {
+        stdio: 'inherit',
+    }
+);

--- a/node/build.js
+++ b/node/build.js
@@ -1,9 +1,17 @@
 const child_process = require('child_process');
+const semver = require('semver');
+
+const environmentVariables = {...process.env};
+
+if (semver.satisfies(process.version, '>=17')) {
+    environmentVariables['NODE_OPTIONS'] = '--openssl-legacy-provider';
+}
 
 child_process.spawn(
     'webpack',
     [],
     {
+        env: environmentVariables,
         stdio: 'inherit',
     }
 );

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   },
   "main": "src/twig.js",
   "engines": {
-    "node": ">=8.16"
+    "node": ">=10"
   },
   "bin": {
     "twigjs": "./bin/twigjs"

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "postversion": "git push origin master && git push origin master --tags",
     "pretest": "npm run build",
     "test": "mocha -r should",
-    "build": "webpack",
+    "build": "node node/build.js",
     "posttest": "xo src lib bin"
   },
   "dependencies": {


### PR DESCRIPTION
This supersedes #835 and tests up to Node v18.

I ended up creating a proxy script to run webpack and detect when Node v17+ is being used and add the Node flag accordingly.