### PR TITLE
Adds the (string) position of tokens to the token tree.

### DIFF
--- a/src/twig.expression.js
+++ b/src/twig.expression.js
@@ -1118,11 +1118,12 @@ module.exports = function (Twig) {
     /**
      * Break an expression into tokens defined in Twig.expression.definitions.
      *
-     * @param {string} expression The string to tokenize.
+     * @param {Object} rawToken The string to tokenize.
      *
      * @return {Array} An array of tokens.
      */
-    Twig.expression.tokenize = function (expression) {
+    Twig.expression.tokenize = function (rawToken) {
+        let expression = rawToken.value;
         const tokens = [];
         // Keep an offset of the location in the expression for error messages.
         let expOffset = 0;
@@ -1170,11 +1171,17 @@ module.exports = function (Twig) {
 
             invalidMatches = [];
 
-            tokens.push({
+            const token = {
                 type,
                 value: match[0],
                 match
-            });
+            };
+
+            if (rawToken.position) {
+                token.position = rawToken.position;
+            }
+
+            tokens.push(token);
 
             matchFound = true;
             next = tokenNext;
@@ -1240,15 +1247,14 @@ module.exports = function (Twig) {
      * @return {Object} The compiled token.
      */
     Twig.expression.compile = function (rawToken) {
-        const expression = rawToken.value;
         // Tokenize expression
-        const tokens = Twig.expression.tokenize(expression);
+        const tokens = Twig.expression.tokenize(rawToken);
         let token = null;
         const output = [];
         const stack = [];
         let tokenTemplate = null;
 
-        Twig.log.trace('Twig.expression.compile: ', 'Compiling ', expression);
+        Twig.log.trace('Twig.expression.compile: ', 'Compiling ', rawToken.value);
 
         // Push tokens into RPN stack using the Shunting-yard algorithm
         // See http://en.wikipedia.org/wiki/Shunting_yard_algorithm

--- a/test/test.core.js
+++ b/test/test.core.js
@@ -508,4 +508,22 @@ describe('Twig.js Core ->', function () {
             }).should.throw(/Unable to find template file/);
         });
     });
+
+    describe('tokens should have the correct positions in template', () => {
+        it('should show the correct token positions in a simple template', () => {
+            const tokens = twig({data: '{{ unit }}'}).tokens;
+            tokens[0].position.should.eql({start: 0, end: 10});
+        });
+
+        it('should show the correct token positions in a advanced template', () => {
+            const tokens = twig({data:'I want to {{ try }} a more {% if advanced | length > 3 %}{{ variable }}{% endif %} template {% set unit = 2 %}{# This is a comment #}{{ variable_after_comment }}'}).tokens;
+            tokens[0].position.should.eql({start: 0, end: 10});
+            tokens[1].position.should.eql({start: 10, end: 19});
+            tokens[2].position.should.eql({start: 19, end: 27});
+            tokens[3].position.should.eql({open: {start: 27, end: 57}, close: {start: 71, end: 82}});
+            tokens[3].token.output[0].position.should.eql({start: 57, end: 71});
+            tokens[5].position.should.eql({start: 92, end: 110});
+            tokens[6].position.should.eql({start: 133, end: 161});
+        });
+    });
 });


### PR DESCRIPTION
This PR adds the position to the tokens in the token tree. 

Example found in the following string:
`I want to {{ try }} a more {% if advanced | length > 3 %}{{ variable }}{% endif %} template {% set unit = 2 %}{# This is a comment #}{{ variable_after_comment }}`

```
  {
    type: 'raw',
    value: ' template ',
    position: { start: 82, end: 92 }
  },
```

This means the raw text ` template ` can be found between position 82 and 92 in the given template.

This is one of a series of PRs I want to make to parse through tokens and to act on these tokens. Like the NodeTraverser of Twig in PHP.