### PR TITLE
Add support for arrow functions

### DIFF
--- a/src/twig.expression.js
+++ b/src/twig.expression.js
@@ -486,7 +486,7 @@ module.exports = function (Twig) {
              * Match a filter callback function (after a filter).
              * ((params) => body)
              */
-            type: Twig.expression.type.filterCallbackFunction,
+            type: Twig.expression.type.arrowFunction,
             regex: /^\(\(*\s*([a-zA-Z_]\w*\s*(?:\s?,\s?[a-zA-Z_]\w*\s*)*)\)*\s*=>\s*([^,]*),*\s*(\w*(?:,\s?\w*)*)\s*\)/,
             next: Twig.expression.set.expressions.concat([Twig.expression.type.subexpression.end]),
             compile(token, stack, output) {

--- a/src/twig.expression.js
+++ b/src/twig.expression.js
@@ -492,7 +492,7 @@ module.exports = function (Twig) {
             compile(token, stack, output) {
                 const filter = output.pop();
                 if (filter.type !== Twig.expression.type.filter) {
-                    throw new Twig.Error('Expected filter before filterCallbackFunction.');
+                    throw new Twig.Error('Expected filter before arrow function.');
                 }
 
                 token.params = token.match[1].trim();

--- a/src/twig.expression.js
+++ b/src/twig.expression.js
@@ -214,9 +214,9 @@ module.exports = function (Twig) {
         },
         {
             type: Twig.expression.type.operator.binary,
-            // Match any of ??, ?:, +, *, /, -, %, ~, <, <=, >, >=, !=, ==, **, ?, :, and, b-and, or, b-or, b-xor, in, not in
+            // Match any of ??, ?:, +, *, /, -, %, ~, <=>, <, <=, >, >=, !=, ==, **, ?, :, and, b-and, or, b-or, b-xor, in, not in
             // and, or, in, not in, matches, starts with, ends with can be followed by a space or parenthesis
-            regex: /(^\?\?|^\?:|^(b-and)|^(b-or)|^(b-xor)|^[+\-~%?]|^[:](?!\d\])|^[!=]==?|^[!<>]=?|^\*\*?|^\/\/?|^(and)[(|\s+]|^(or)[(|\s+]|^(in)[(|\s+]|^(not in)[(|\s+]|^(matches)|^(starts with)|^(ends with)|^\.\.)/,
+            regex: /(^\?\?|^\?:|^(b-and)|^(b-or)|^(b-xor)|^[+\-~%?]|^(<=>)|^[:](?!\d\])|^[!=]==?|^[!<>]=?|^\*\*?|^\/\/?|^(and)[(|\s+]|^(or)[(|\s+]|^(in)[(|\s+]|^(not in)[(|\s+]|^(matches)|^(starts with)|^(ends with)|^\.\.)/,
             next: Twig.expression.set.expressions,
             transform(match, tokens) {
                 switch (match[0]) {

--- a/src/twig.expression.js
+++ b/src/twig.expression.js
@@ -487,7 +487,7 @@ module.exports = function (Twig) {
              * ((params) => body)
              */
             type: Twig.expression.type.filterCallbackFunction,
-            regex: /^\(\(([\w\s]+(?:,\s?[\w\s]+)*)\)\s*=>\s*[{}]*(.*)[}]*\)/,
+            regex: /^\(\(*([\w\s]+(?:,\s?[\w\s]+)*)\)*\s*=>\s*[{}]*(.*)[}]*\)/,
             next: Twig.expression.set.expressions.concat([Twig.expression.type.subexpression.end]),
             compile(token, stack, output) {
                 const filter = output.pop();
@@ -496,7 +496,7 @@ module.exports = function (Twig) {
                 }
 
                 filter.params = token;
-                token.params = token.match[1];
+                token.params = token.match[1].trim();
                 token.body = '{{ ' + token.match[2] + ' }}';
                 output.push(filter);
             },

--- a/src/twig.expression.js
+++ b/src/twig.expression.js
@@ -72,7 +72,7 @@ module.exports = function (Twig) {
         // What can follow an expression (in general)
         operations: [
             Twig.expression.type.filter,
-            Twig.expression.type.filterCallbackFunction,
+            Twig.expression.type.arrowFunction,
             Twig.expression.type.operator.unary,
             Twig.expression.type.operator.binary,
             Twig.expression.type.array.end,

--- a/src/twig.expression.js
+++ b/src/twig.expression.js
@@ -35,7 +35,7 @@ module.exports = function (Twig) {
             unary: 'Twig.expression.type.operator.unary',
             binary: 'Twig.expression.type.operator.binary'
         },
-        filterCallbackFunction: 'Twig.expression.type.filterCallbackFunction',
+        arrowFunction: 'Twig.expression.type.arrowFunction',
         string: 'Twig.expression.type.string',
         bool: 'Twig.expression.type.bool',
         slice: 'Twig.expression.type.slice',

--- a/src/twig.expression.js
+++ b/src/twig.expression.js
@@ -487,7 +487,7 @@ module.exports = function (Twig) {
              * ((params) => body)
              */
             type: Twig.expression.type.filterCallbackFunction,
-            regex: /^\(\(*([\w\s]+(?:,\s?[\w\s]+)*)\)*\s*=>\s*[{}]*(.*)[}]*\)/,
+            regex: /^\(\(*\s*([a-zA-Z_]\w*\s*(?:\s?,\s?[a-zA-Z_]\w*\s*)*)\)*\s*=>\s*([^,]*),*\s*(\w*(?:,\s?\w*)*)\s*\)/,
             next: Twig.expression.set.expressions.concat([Twig.expression.type.subexpression.end]),
             compile(token, stack, output) {
                 const filter = output.pop();
@@ -495,9 +495,11 @@ module.exports = function (Twig) {
                     throw new Twig.Error('Expected filter before filterCallbackFunction.');
                 }
 
-                filter.params = token;
                 token.params = token.match[1].trim();
                 token.body = '{{ ' + token.match[2] + ' }}';
+                token.args = token.match[3].trim();
+                filter.params = token;
+
                 output.push(filter);
             },
             parse(token, stack) {

--- a/src/twig.expression.js
+++ b/src/twig.expression.js
@@ -483,7 +483,7 @@ module.exports = function (Twig) {
         },
         {
             /**
-             * Match a filter callback function (after a filter).
+             * Match an arrow function after a filter.
              * ((params) => body)
              */
             type: Twig.expression.type.arrowFunction,

--- a/src/twig.expression.js
+++ b/src/twig.expression.js
@@ -783,7 +783,7 @@ module.exports = function (Twig) {
             // Match a | then a letter or _, then any number of letters, numbers, _ or -
             regex: /^\|\s?([a-zA-Z_][a-zA-Z0-9_-]*)/,
             next: Twig.expression.set.operationsExtended.concat([
-                Twig.expression.type.filterCallbackFunction,
+                Twig.expression.type.arrowFunction,
                 Twig.expression.type.parameter.start
             ]),
             compile(token, stack, output) {

--- a/src/twig.expression.operator.js
+++ b/src/twig.expression.operator.js
@@ -93,6 +93,11 @@ module.exports = function (Twig) {
                 token.associativity = Twig.expression.operator.leftToRight;
                 break;
 
+            case '<=>':
+                token.precidence = 9;
+                token.associativity = Twig.expression.operator.leftToRight;
+                break;
+
             case '<':
             case '<=':
             case '>':
@@ -273,6 +278,10 @@ module.exports = function (Twig) {
             case 'not':
             case '!':
                 stack.push(!Twig.lib.boolval(b));
+                break;
+
+            case '<=>':
+                stack.push(a === b ? 0 : (a < b ? -1 : 1));
                 break;
 
             case '<':

--- a/src/twig.filters.js
+++ b/src/twig.filters.js
@@ -72,9 +72,24 @@ module.exports = function (Twig) {
                 return value;
             }
         },
-        sort(value) {
+        sort(value, params) {
             if (is('Array', value)) {
-                return value.sort();
+                let ret;
+                if (params) {
+                    const callBackParams = params.params.split(',');
+                    ret = value.sort((_a, _b) => {
+                        const data = {};
+                        data[callBackParams[0]] = _a;
+                        data[callBackParams[1]] = _b;
+
+                        const template = Twig.exports.twig({data: params.body});
+                        return template.render(data);
+                    });
+                } else {
+                    ret = value.sort();
+                }
+
+                return ret;
             }
 
             if (is('Object', value)) {

--- a/src/twig.filters.js
+++ b/src/twig.filters.js
@@ -865,6 +865,20 @@ module.exports = function (Twig) {
                 });
                 return newValue;
             }
+        },
+        reduce(value, params) {
+            if (is('Array', value)) {
+                const callBackParams = params.params.split(',');
+                return value.reduce((_carry, _v, _k) => {
+                    const data = {};
+                    data[callBackParams[0]] = _carry;
+                    data[callBackParams[1].trim()] = _v;
+                    data[callBackParams[2].trim()] = _k;
+
+                    const template = Twig.exports.twig({data: params.body});
+                    return template.render(data);
+                }, params.args || 0);
+            }
         }
     };
 

--- a/src/twig.filters.js
+++ b/src/twig.filters.js
@@ -835,6 +835,17 @@ module.exports = function (Twig) {
         },
         spaceless(value) {
             return value.replace(/>\s+</g, '><').trim();
+        },
+        filter(value, params) {
+            if (is('Array', value)) {
+                return value.filter(_a => {
+                    const data = {};
+                    data[params.params] = _a;
+
+                    const template = Twig.exports.twig({data: params.body});
+                    return template.render(data) === 'true';
+                });
+            }
         }
     };
 

--- a/src/twig.filters.js
+++ b/src/twig.filters.js
@@ -855,9 +855,9 @@ module.exports = function (Twig) {
                 const newValue = [];
                 value.forEach((_b, _a) => {
                     const data = {};
-                    data[callBackParams[0]] = _b;
+                    data[callBackParams[0].trim()] = _b;
                     if (callBackParams[1]) {
-                        data[callBackParams[1]] = _a;
+                        data[callBackParams[1].trim()] = _a;
                     }
 
                     const template = Twig.exports.twig({data: params.body});

--- a/src/twig.filters.js
+++ b/src/twig.filters.js
@@ -846,6 +846,25 @@ module.exports = function (Twig) {
                     return template.render(data) === 'true';
                 });
             }
+        },
+        map(value, params) {
+            if (is('Array', value)) {
+                const callBackParams = params.params.split(',');
+                // Since Javascript does not support a callBack function to map() with both keys and values; we use forEach here
+                // Note: Twig and PHP use ((value[, key])) for map(); whereas Javascript uses (([key, ]value)) for forEach()
+                const newValue = [];
+                value.forEach((_b, _a) => {
+                    const data = {};
+                    data[callBackParams[0]] = _b;
+                    if (callBackParams[1]) {
+                        data[callBackParams[1]] = _a;
+                    }
+
+                    const template = Twig.exports.twig({data: params.body});
+                    newValue[_a] = template.render(data);
+                });
+                return newValue;
+            }
         }
     };
 

--- a/test/test.expressions.js
+++ b/test/test.expressions.js
@@ -173,6 +173,13 @@ describe('Twig.js Expressions ->', function () {
             {a: false, b: true},
             {a: false, b: false}
         ];
+        it('should support spaceship operator', function () {
+            const testTemplate = twig({data: '{{ a <=> b }}'});
+            numericTestData.forEach(pair => {
+                const output = testTemplate.render(pair);
+                output.should.equal((pair.a === pair.b ? 0 : (pair.a < pair.b ? -1 : 1)).toString());
+            });
+        });
         it('should support less then', function () {
             const testTemplate = twig({data: '{{ a < b }}'});
             numericTestData.forEach(pair => {

--- a/test/test.filters.js
+++ b/test/test.filters.js
@@ -873,6 +873,11 @@ describe('Twig.js Filters ->', function () {
 
     describe('map ->', function () {
         it('should map an array (with keys)', function () {
+            let testTemplate = twig({data: '{{ [1,5,2,7,8]|map((v, k) => v*v+k) }}'});
+            testTemplate.render().should.equal('1,26,6,52,68');
+        });
+        
+        it('should map an array', function () {
             let testTemplate = twig({data: '{{ [1,5,2,7,8]|map((v) => v*v) }}'});
             testTemplate.render().should.equal('1,25,4,49,64');
         });

--- a/test/test.filters.js
+++ b/test/test.filters.js
@@ -151,6 +151,10 @@ describe('Twig.js Filters ->', function () {
             testTemplate = twig({data: '{% set obj = {\'z\':\'abc\',\'a\':2,\'y\':7,\'m\':\'test\'} %}{% for key,value in obj|sort %}{{key}}:{{value}} {%endfor %}'});
             testTemplate.render().should.equal('a:2 y:7 z:abc m:test ');
         });
+        it('should sort an array of objects with a callback function', function () {
+            let testTemplate = twig({data: '{% for item in items|sort((left,right) => left.num - right.num) %}{{ item|json_encode }}{% endfor %}'});
+            testTemplate.render({items:[{id: 1,num: 6},{id: 2, num: 3},{id: 3, num: 4}]}).should.equal('{"id":2,"num":3}{"id":3,"num":4}{"id":1,"num":6}');
+        });
 
         it('should handle undefined', function () {
             const testTemplate = twig({data: '{% set obj = undef|sort %}{% for key, value in obj|sort %}{{key}}:{{value}}{%endfor%}'});

--- a/test/test.filters.js
+++ b/test/test.filters.js
@@ -871,6 +871,13 @@ describe('Twig.js Filters ->', function () {
         });
     });
 
+    describe('map ->', function () {
+        it('should map an array (with keys)', function () {
+            let testTemplate = twig({data: '{{ [1,5,2,7,8]|map((v) => v*v) }}'});
+            testTemplate.render().should.equal('1,25,4,49,64');
+        });
+    });
+
     it('should chain', function () {
         const testTemplate = twig({data: '{{ ["a", "b", "c"]|keys|reverse }}'});
         testTemplate.render().should.equal('2,1,0');

--- a/test/test.filters.js
+++ b/test/test.filters.js
@@ -883,6 +883,18 @@ describe('Twig.js Filters ->', function () {
         });
     });
 
+    describe('reduce ->', function () {
+        it('should reduce an array (with inital value)', function () {
+            let testTemplate = twig({data: '{{ [1,2,3]|reduce((carry, v, k) => carry + v * k) }}'});
+            testTemplate.render().should.equal('8');
+        });
+        
+        it('should reduce an array)', function () {
+            let testTemplate = twig({data: '{{ [1,2,3]|reduce((carry, v, k) => carry + v * k, 10) }}'});
+            testTemplate.render().should.equal('18');
+        });
+    });
+
     it('should chain', function () {
         const testTemplate = twig({data: '{{ ["a", "b", "c"]|keys|reverse }}'});
         testTemplate.render().should.equal('2,1,0');

--- a/test/test.filters.js
+++ b/test/test.filters.js
@@ -859,6 +859,18 @@ describe('Twig.js Filters ->', function () {
         });
     });
 
+    describe('filter ->', function () {
+        it('should filter an array (with perenthesis)', function () {
+            let testTemplate = twig({data: '{{ [1,5,2,7,8]|filter((f) => f % 2 == 0) }}'});
+            testTemplate.render().should.equal('2,8');
+        });
+
+        it('should filter an array (without perenthesis)', function () {
+            let testTemplate = twig({data: '{{ [1,5,2,7,8]|filter(f => f % 2 == 0) }}'});
+            testTemplate.render().should.equal('2,8');
+        });
+    });
+
     it('should chain', function () {
         const testTemplate = twig({data: '{{ ["a", "b", "c"]|keys|reverse }}'});
         testTemplate.render().should.equal('2,1,0');


### PR DESCRIPTION
Aiming to resolve #652 

I'm not (yet) quite convinced if this is the way to go; would really like to get some discussion going on how to approach this and eventually  get this fixed and merged.

Implementation of arrow functions in filters:
- sort
- filter
- map
- reduce

Object manipulation is not really supported; this implementation accepts a callbackFunction (Twig syntax) which is compiled and parsed as a new (runtime) template. The return values (e.g. output) of the callBackFunctions are delegated to their respective JS functions.

As previously stated: this is merely a functional (read dirty) workaround; but for most of the use cases it will do the trick.
