### PR TITLE
Arrow functions

### DIFF
--- a/src/twig.filters.js
+++ b/src/twig.filters.js
@@ -850,6 +850,25 @@ module.exports = function (Twig) {
                     return template.render(data) === 'true';
                 });
             }
+        },
+        map(value, params) {
+            if (is('Array', value)) {
+                const callBackParams = params.params.split(',');
+                // Since Javascript does not support a callBack function to map() with both keys and values; we use forEach here
+                // Note: Twig and PHP use ((value[, key])) for map(); whereas Javascript uses (([key, ]value)) for forEach()
+                const newValue = [];
+                value.forEach((_b, _a) => {
+                    const data = {};
+                    data[callBackParams[0].trim()] = _b;
+                    if (callBackParams[1]) {
+                        data[callBackParams[1].trim()] = _a;
+                    }
+
+                    const template = Twig.exports.twig({data: params.body});
+                    newValue[_a] = template.render(data);
+                });
+                return newValue;
+            }
         }
     };
 

--- a/src/twig.filters.js
+++ b/src/twig.filters.js
@@ -72,9 +72,24 @@ module.exports = function (Twig) {
                 return value;
             }
         },
-        sort(value) {
+        sort(value, params) {
             if (is('Array', value)) {
-                return value.sort();
+                let ret;
+                if (params) {
+                    const callBackParams = params.params.split(',');
+                    ret = value.sort((_a, _b) => {
+                        const data = {};
+                        data[callBackParams[0]] = _a;
+                        data[callBackParams[1]] = _b;
+
+                        const template = Twig.exports.twig({data: params.body});
+                        return template.render(data);
+                    });
+                } else {
+                    ret = value.sort();
+                }
+
+                return ret;
             }
 
             if (is('Object', value)) {

--- a/src/twig.filters.js
+++ b/src/twig.filters.js
@@ -839,6 +839,17 @@ module.exports = function (Twig) {
         },
         spaceless(value) {
             return value.replace(/>\s+</g, '><').trim();
+        },
+        filter(value, params) {
+            if (is('Array', value)) {
+                return value.filter(_a => {
+                    const data = {};
+                    data[params.params] = _a;
+
+                    const template = Twig.exports.twig({data: params.body});
+                    return template.render(data) === 'true';
+                });
+            }
         }
     };
 

--- a/src/twig.filters.js
+++ b/src/twig.filters.js
@@ -869,6 +869,20 @@ module.exports = function (Twig) {
                 });
                 return newValue;
             }
+        },
+        reduce(value, params) {
+            if (is('Array', value)) {
+                const callBackParams = params.params.split(',');
+                return value.reduce((_carry, _v, _k) => {
+                    const data = {};
+                    data[callBackParams[0]] = _carry;
+                    data[callBackParams[1].trim()] = _v;
+                    data[callBackParams[2].trim()] = _k;
+
+                    const template = Twig.exports.twig({data: params.body});
+                    return template.render(data);
+                }, params.args || 0);
+            }
         }
     };
 

--- a/test/test.filters.js
+++ b/test/test.filters.js
@@ -887,6 +887,18 @@ describe('Twig.js Filters ->', function () {
         });
     });
 
+    describe('reduce ->', function () {
+        it('should reduce an array (with inital value)', function () {
+            let testTemplate = twig({data: '{{ [1,2,3]|reduce((carry, v, k) => carry + v * k) }}'});
+            testTemplate.render().should.equal('8');
+        });
+        
+        it('should reduce an array)', function () {
+            let testTemplate = twig({data: '{{ [1,2,3]|reduce((carry, v, k) => carry + v * k, 10) }}'});
+            testTemplate.render().should.equal('18');
+        });
+    });
+
     it('should chain', function () {
         const testTemplate = twig({data: '{{ ["a", "b", "c"]|keys|reverse }}'});
         testTemplate.render().should.equal('2,1,0');

--- a/test/test.filters.js
+++ b/test/test.filters.js
@@ -151,6 +151,10 @@ describe('Twig.js Filters ->', function () {
             testTemplate = twig({data: '{% set obj = {\'z\':\'abc\',\'a\':2,\'y\':7,\'m\':\'test\'} %}{% for key,value in obj|sort %}{{key}}:{{value}} {%endfor %}'});
             testTemplate.render().should.equal('a:2 y:7 z:abc m:test ');
         });
+        it('should sort an array of objects with an arrow function', function () {
+            let testTemplate = twig({data: '{% for item in items|sort((left,right) => left.num - right.num) %}{{ item|json_encode }}{% endfor %}'});
+            testTemplate.render({items:[{id: 1,num: 6},{id: 2, num: 3},{id: 3, num: 4}]}).should.equal('{"id":2,"num":3}{"id":3,"num":4}{"id":1,"num":6}');
+        });
 
         it('should handle undefined', function () {
             const testTemplate = twig({data: '{% set obj = undef|sort %}{% for key, value in obj|sort %}{{key}}:{{value}}{%endfor%}'});

--- a/test/test.filters.js
+++ b/test/test.filters.js
@@ -875,6 +875,18 @@ describe('Twig.js Filters ->', function () {
         });
     });
 
+    describe('map ->', function () {
+        it('should map an array (with keys)', function () {
+            let testTemplate = twig({data: '{{ [1,5,2,7,8]|map((v, k) => v*v+k) }}'});
+            testTemplate.render().should.equal('1,26,6,52,68');
+        });
+        
+        it('should map an array', function () {
+            let testTemplate = twig({data: '{{ [1,5,2,7,8]|map((v) => v*v) }}'});
+            testTemplate.render().should.equal('1,25,4,49,64');
+        });
+    });
+
     it('should chain', function () {
         const testTemplate = twig({data: '{{ ["a", "b", "c"]|keys|reverse }}'});
         testTemplate.render().should.equal('2,1,0');

--- a/test/test.filters.js
+++ b/test/test.filters.js
@@ -863,6 +863,18 @@ describe('Twig.js Filters ->', function () {
         });
     });
 
+    describe('filter ->', function () {
+        it('should filter an array (with perenthesis)', function () {
+            let testTemplate = twig({data: '{{ [1,5,2,7,8]|filter((f) => f % 2 == 0) }}'});
+            testTemplate.render().should.equal('2,8');
+        });
+
+        it('should filter an array (without perenthesis)', function () {
+            let testTemplate = twig({data: '{{ [1,5,2,7,8]|filter(f => f % 2 == 0) }}'});
+            testTemplate.render().should.equal('2,8');
+        });
+    });
+
     it('should chain', function () {
         const testTemplate = twig({data: '{{ ["a", "b", "c"]|keys|reverse }}'});
         testTemplate.render().should.equal('2,1,0');


### PR DESCRIPTION
Aiming to resolve https://github.com/twigjs/twig.js/issues/652

I'm not (yet) quite convinced if this is the way to go; would really like to get some discussion going on how to approach this and eventually get this fixed and merged.

Implementation of arrow functions in filters:

    sort
    filter
    map
    reduce

Object manipulation is not really supported; this implementation accepts a arrowFunction (Twig syntax) which is compiled and parsed as a new (runtime) template. The return values (e.g. output) of the arrowFunction are delegated to their respective JS functions.

As previously stated: this is merely a functional (read dirty) workaround; but for most of the use cases it will do the trick.