### PR TITLE
Allow colon inside Twig.expression.type.key.brackets.

### DIFF
--- a/src/twig.expression.js
+++ b/src/twig.expression.js
@@ -913,7 +913,7 @@ module.exports = function (Twig) {
         },
         {
             type: Twig.expression.type.key.brackets,
-            regex: /^\[([^\]:]*)\]/,
+            regex: /^\[([^\]]*)\]/,
             next: Twig.expression.set.operationsExtended.concat([
                 Twig.expression.type.parameter.start
             ]),

--- a/test/test.expressions.js
+++ b/test/test.expressions.js
@@ -325,6 +325,11 @@ describe('Twig.js Expressions ->', function () {
             const testTemplate = twig({data: '{% if a is defined and a %}true{% else %}false{% endif %}'});
             testTemplate.render({a: ['value']}).should.equal('true');
         });
+
+        it('should be able to access array elements with colons', function () {
+            const testTemplate = twig({data: '{% for d in data["test:element"] %}{{ d.id }}{% endfor %}'});
+            testTemplate.render({data: {'test:element':[{'id': 100}]}}).should.equal('100');
+        });
     });
 
     describe('Other Operators ->', function () {


### PR DESCRIPTION
Fixes #854

Not sure why the colon is needed in de regexp for Twig.expression.type.key.brackets, @willrowe can you elaborate?

If it is not needed, removing the colon in the regexp will fix this issue.