### PR TITLE
Allow whitespace in extended ternary operator for false conditions.

### DIFF
--- a/src/twig.expression.js
+++ b/src/twig.expression.js
@@ -214,7 +214,7 @@ module.exports = function (Twig) {
             type: Twig.expression.type.operator.binary,
             // Match any of ??, ?:, +, *, /, -, %, ~, <=>, <, <=, >, >=, !=, ==, **, ?, :, and, b-and, or, b-or, b-xor, in, not in
             // and, or, in, not in, matches, starts with, ends with can be followed by a space or parenthesis
-            regex: /(^\?\?|^\?:|^(b-and)|^(b-or)|^(b-xor)|^[+\-~%?]|^(<=>)|^[:](?!\d\])|^[!=]==?|^[!<>]=?|^\*\*?|^\/\/?|^(and)[(|\s+]|^(or)[(|\s+]|^(in)[(|\s+]|^(not in)[(|\s+]|^(matches)|^(starts with)|^(ends with)|^\.\.)/,
+            regex: /(^\?\?|^\?\s*:|^(b-and)|^(b-or)|^(b-xor)|^[+\-~%?]|^(<=>)|^[:](?!\d\])|^[!=]==?|^[!<>]=?|^\*\*?|^\/\/?|^(and)[(|\s+]|^(or)[(|\s+]|^(in)[(|\s+]|^(not in)[(|\s+]|^(matches)|^(starts with)|^(ends with)|^\.\.)/,
             next: Twig.expression.set.expressions,
             transform(match, tokens) {
                 switch (match[0]) {
@@ -231,6 +231,10 @@ module.exports = function (Twig) {
             },
             compile(token, stack, output) {
                 delete token.match;
+
+                if (token.value.match(/^\?\s*:/)) {
+                    token.value = '?:';
+                }
 
                 token.value = token.value.trim();
                 const {value} = token;

--- a/test/test.expressions.operators.js
+++ b/test/test.expressions.operators.js
@@ -53,6 +53,15 @@ describe('Twig.js Expression Operators ->', function () {
             outputT.should.equal('one');
             outputF.should.equal('two');
         });
+
+        it('should support the extended ternary operator for false conditions (with whitespace in between operators)', function () {
+            const testTemplate = twig({data: '{{ a ?   : b }}'});
+            const outputT = testTemplate.render({a: 'one', b: 'two'});
+            const outputF = testTemplate.render({a: false, b: 'two'});
+
+            outputT.should.equal('one');
+            outputF.should.equal('two');
+        });
     });
 
     describe('?? ->', function () {


### PR DESCRIPTION
Fixes #903 