### PR TITLE
Provide PHP style output of booleans by specifying option.

### DIFF
--- a/src/twig.core.js
+++ b/src/twig.core.js
@@ -695,6 +695,18 @@ module.exports = function (Twig) {
      */
     Twig.output = function (output) {
         const {autoescape} = this.options;
+        const {phpStyleBooleans} = this.options;
+
+        // Conform Javascript boolean to PHP boolean
+        if (phpStyleBooleans) {
+            output = output.map(str => {
+                if (typeof str === 'boolean') {
+                    str = str ? '1' : '';
+                }
+
+                return str;
+            });
+        }
 
         if (!autoescape) {
             return output.join('');

--- a/src/twig.core.js
+++ b/src/twig.core.js
@@ -698,15 +698,17 @@ module.exports = function (Twig) {
         const {phpStyleBooleans} = this.options;
 
         // Conform Javascript boolean to PHP boolean
-        if (phpStyleBooleans) {
-            output = output.map(str => {
-                if (typeof str === 'boolean') {
+        output = output.map(str => {
+            if (typeof str === 'boolean') {
+                if (phpStyleBooleans === undefined) {
+                    console.warn('Deprecation notice: `phpStyleBooleans` is not defined, output differs from PHP behavior, in future versions this behavior will be changed to PHP style booleans.');
+                } else if (phpStyleBooleans) {
                     str = str ? '1' : '';
                 }
+            }
 
-                return str;
-            });
-        }
+            return str;
+        });
 
         if (!autoescape) {
             return output.join('');

--- a/src/twig.exports.js
+++ b/src/twig.exports.js
@@ -23,6 +23,7 @@ module.exports = function (Twig) {
             // TODO: turn autoscape on in the next major version
             autoescape: (params.autoescape !== null && params.autoescape) || false,
             allowInlineIncludes: params.allowInlineIncludes || false,
+            phpStyleBooleans: params.phpStyleBooleans || false,
             rethrow: params.rethrow || false,
             namespaces: params.namespaces
         };

--- a/src/twig.exports.js
+++ b/src/twig.exports.js
@@ -23,7 +23,8 @@ module.exports = function (Twig) {
             // TODO: turn autoscape on in the next major version
             autoescape: (params.autoescape !== null && params.autoescape) || false,
             allowInlineIncludes: params.allowInlineIncludes || false,
-            phpStyleBooleans: params.phpStyleBooleans || false,
+            // TODO: turn phpStyleBooleans on in the next major version
+            phpStyleBooleans: undefined,
             rethrow: params.rethrow || false,
             namespaces: params.namespaces
         };
@@ -38,6 +39,10 @@ module.exports = function (Twig) {
 
         if (params.trace !== undefined) {
             Twig.trace = params.trace;
+        }
+
+        if (params.phpStyleBooleans !== undefined) {
+            options.phpStyleBooleans = params.phpStyleBooleans;
         }
 
         if (params.data !== undefined) {

--- a/test/test.core.js
+++ b/test/test.core.js
@@ -147,6 +147,11 @@ describe('Twig.js Core ->', function () {
         twig({data: '{{ false }}'}).render().should.equal('false');
     });
 
+    it('should be able to output booleans (PHP style)', function () {
+        twig({phpStyleBooleans: true, data: '{{ false }}'}).render().should.equal('');
+        twig({phpStyleBooleans: true, data: '{{ true }}'}).render().should.equal('1');
+    });
+
     it('should be able to output strings', function () {
         twig({data: '{{ "double" }}'}).render().should.equal('double');
         twig({data: '{{ \'single\' }}'}).render().should.equal('single');


### PR DESCRIPTION
I'm not sure if this is the way to go, since this is a very old issue.
Please share your thoughts @willrowe && @RobLoach about this fix.

Aiming to fix #88 

Since this change breaks every boolean test and / or comparison, I've introduced an option in order to enable PHP style boolean outputs.