### PR TITLE
Support extended ternary operator for undefined argument.

### DIFF
--- a/src/twig.expression.operator.js
+++ b/src/twig.expression.operator.js
@@ -219,7 +219,7 @@ module.exports = function (Twig) {
 
                 break;
             case '?':
-                if (a === undefined) {
+                if (a === undefined && b !== undefined) {
                     // An extended ternary.
                     a = b;
                     b = c;

--- a/test/test.expressions.operators.js
+++ b/test/test.expressions.operators.js
@@ -62,6 +62,19 @@ describe('Twig.js Expression Operators ->', function () {
             outputT.should.equal('one');
             outputF.should.equal('two');
         });
+
+        it('should support the extended ternary operator for undefined arguments', function () {
+            const testTemplate = twig({data: '{{ test1 ? test1 : test2 }}'});
+            const outputA = testTemplate.render({test2: 'text 2'});
+            const outputB = testTemplate.render({test1: false});
+            const outputC = testTemplate.render({});
+            const outputD = testTemplate.render({test1: 'text 1'});
+
+            outputA.should.equal('text 2');
+            outputB.should.equal('');
+            outputC.should.equal('');
+            outputD.should.equal('text 1');
+        });
     });
 
     describe('?? ->', function () {


### PR DESCRIPTION
Attempting to fix #894 

Do not shift arguments when ternary operand is undefined.