### PR TITLE
chore: extend .npmignore

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -4,11 +4,16 @@ test
 test-ext
 docs
 qtest
+.github
 .hg
 .git
 .gitignore
 .gitmodules
 .travis.yml
 .idea
+.editorconfig
+.nojekyll
+eslint.config.mjs
+node
 webpack.config.js
 bower.json


### PR DESCRIPTION
This is purely cosmetic as it doesn't reduce the package size - roughly 2kB saved.