### PR TITLE
Fix `first` filter for numbers

### DIFF
--- a/src/twig.filters.js
+++ b/src/twig.filters.js
@@ -683,6 +683,8 @@ module.exports = function (Twig) {
                 }
             } else if (typeof value === 'string') {
                 return value.slice(0, 1);
+            } else if (is('Number', value)) {
+                return value.toString().slice(0, 1);
             }
         },
 

--- a/test/test.filters.js
+++ b/test/test.filters.js
@@ -720,6 +720,16 @@ describe('Twig.js Filters ->', function () {
             const testTemplate = twig({data: '{{ \'abcde\'|first }}'});
             testTemplate.render().should.equal('a');
         });
+        it('should return the first digit of numbers', function () {
+            const singleDigitTemplate = twig({data: '{{ 1|first }}'});
+            singleDigitTemplate.render().should.equal('1');
+
+            const multiDigitTemplate = twig({data: '{{ 234|first }}'});
+            multiDigitTemplate.render().should.equal('2');
+
+            const floatTemplate = twig({data: '{{ 5.67|first }}'});
+            floatTemplate.render().should.equal('5');
+        });
     });
 
     describe('split ->', function () {


### PR DESCRIPTION
The `last` filter was updated in 74e681a to return the last digit of a number, matching TwigPHP, but its counterpart `first` never got the same treatment. As a result `{{ 130|first }}` renders an empty string while `{{ 130|last }}` renders `0`.

In TwigPHP both filters run the value through `slice`, which casts a scalar to a string before taking the substring, so `first` of a number is its first digit. This adds the missing `Number` branch to `first`, mirroring what `last` already does, and adds a test next to the existing `last` number test.