### PR TITLE
Report a syntax error for unclosed brackets in expressions

### DIFF
--- a/src/twig.expression.js
+++ b/src/twig.expression.js
@@ -103,6 +103,15 @@ module.exports = function (Twig) {
         Twig.expression.type.slice
     ]);
 
+    // The closing bracket expected for each token that opens a group. Used to
+    // detect an unclosed group left on the stack after an expression is compiled.
+    Twig.expression.closingBracket = {
+        [Twig.expression.type.object.start]: '}',
+        [Twig.expression.type.array.start]: ']',
+        [Twig.expression.type.parameter.start]: ')',
+        [Twig.expression.type.subexpression.start]: ')'
+    };
+
     // Some commonly used compile and parse functions.
     Twig.expression.fn = {
         compile: {
@@ -1323,8 +1332,17 @@ module.exports = function (Twig) {
             Twig.log.trace('Twig.expression.compile: ', 'Output is', output);
         }
 
+        // A well formed expression closes every group it opens, so once the
+        // input is consumed the stack should only hold operators. An opening
+        // bracket left here is an unclosed group and must be reported rather
+        // than silently flushed into the output.
         while (stack.length > 0) {
-            output.push(stack.pop());
+            token = stack.pop();
+            if (Object.prototype.hasOwnProperty.call(Twig.expression.closingBracket, token.type)) {
+                throw new Twig.Error('Expected closing \'' + Twig.expression.closingBracket[token.type] + '\' in expression \'' + rawToken.value + '\'');
+            }
+
+            output.push(token);
         }
 
         Twig.log.trace('Twig.expression.compile: ', 'Final output is', output);

--- a/test/test.regression.js
+++ b/test/test.regression.js
@@ -36,4 +36,22 @@ describe('Twig.js Regression Tests ->', function () {
         const testTemplate = twig({data: str});
         testTemplate.render().should.equal(expected);
     });
+
+    it('#896 should report a syntax error for an unclosed brace instead of rendering [object Object]', function () {
+        // '{{{ ... }}' opens an object with the extra '{' that is never closed.
+        // It used to render as '[object Object]' rather than failing.
+        (function () {
+            twig({rethrow: true, data: 'Hey {{{data.variables.aa | default(\'there\') }}'}).render({data: {variables: {}}});
+        }).should.throw(/Expected closing '}'/);
+
+        (function () {
+            twig({rethrow: true, data: 'Hey {{{data.variables.aa | default(\'there\') }}}'}).render({data: {variables: {}}});
+        }).should.throw(/Expected closing '}'/);
+    });
+
+    it('#896 should still render a triple-open brace whose object is closed', function () {
+        twig({data: '{% for val in arr %}{{{(val.value):null}|json_encode}}{% endfor %}'})
+            .render({arr: [{value: 'one'}, {value: 'two'}]})
+            .should.equal('{"one":null}{"two":null}');
+    });
 });


### PR DESCRIPTION
`{{{ foo }}` rendered as `[object Object]` instead of a syntax error (TwigPHP throws `Unexpected "}"` here, per @ericmorand on the issue). The extra `{` opens an object that never closes, so its group-start token is left on the shunting-yard stack, flushed into the output, and handed back by the parser as-is. `Twig.expression.compile` now throws if an opening `{`, `[` or `(` is still on the stack once the expression is consumed. Valid expressions always pop their start at the matching close, so it can't fire on well-formed input. (By default twig swallows compile errors and renders empty, which is why the reporter's `try/catch` never fired; `rethrow: true` surfaces it like any other syntax error.)

Two calls for you: I made the check cover all four grouping constructs, not just the object from the issue, but I'll narrow it to `{` if you'd rather. And the message is `Expected closing '}'` rather than TwigPHP's `Unexpected "}"` at the trailing brace; matching that exactly is more work, so say the word.

Tests are in `test/test.regression.js`.

closes #896